### PR TITLE
Fix CEMA masking for correct batched/padded processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Megalodon is a unique take on long-context modeling, but [the original repo](htt
 - Complex EMA exposes both a sequential and FFT path; the FFT variant is automatically used during training when cache state is not requested[^5].
 - TimestepNorm keeps the numerically exact Welford update in PyTorch. A Triton/CUDA kernel would be required to match the paper's throughput.
 - Attention dropout uses the standard post-softmax dropout (SDPA-backed when possible); FlashAttention-2 or other custom kernels are not bundled.
-- Streaming cache is chunk-local by default (KV capped at `chunk_size`); set `max_cache_len` above `chunk_size` for sliding-window attention or `cache_unbounded=True` for unbounded KV when VRAM allows. Long-range context still flows through EMA/TimestepNorm state.
+- Streaming cache is chunk-local by default (KV capped at `chunk_size`; `max_cache_len` must be >= `chunk_size` when set); set `max_cache_len` above `chunk_size` for sliding-window attention or `cache_unbounded=True` for unbounded KV when VRAM allows. Long-range context still flows through EMA/TimestepNorm state, and cache positions advance by valid tokens when padding is masked.
 - Cached paths are disabled during training to avoid the slow sequential CEMA path; re-enable only when an optimized sequential kernel exists (tracked in `docs/dev.md`).
 
 [^3]: This repo does not and **will not** include custom CUDA kernels. The goal is to have a readable, hackable PyTorch implementation for experimentation and understanding. Triton kernels may be considered in the future if they can be made optional and do not complicate the codebase.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -89,6 +89,10 @@ A pure-Python Kahan cumsum was tested but is ~10x slower due to the loop; not vi
 
 **Status: ALIGNED (with upstream).** Coefficients follow the upstream alpha/delta/theta parameterization: `p = alpha` (real) and `q = (1 - alpha * delta) * exp(i * theta_k)` with uniformly spaced wavelets. The paper's Eq. (2) includes the same phase factor on the input term; this implementation follows upstream for reproducibility.
 
+### CEMA padding mask handling
+
+**Status: ALIGNED.** `ComplexEMA.forward` accepts a `mask` parameter that zeros masked positions before the EMA recurrence. This prevents TimestepNorm-normalized padding from contaminating the EMA state. Additionally, `h_last` is extracted at the last valid position per batch item (not the absolute end), ensuring cached state matches unbatched processing. This matches the JAX reference implementation.
+
 ### Attention value/gate path (Equations 16, 18, 20)
 
 **Status: ALIGNED.** Matches the reference forward pass:

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -91,7 +91,7 @@ A pure-Python Kahan cumsum was tested but is ~10x slower due to the loop; not vi
 
 ### CEMA padding mask handling
 
-**Status: ALIGNED.** `ComplexEMA.forward` accepts a `mask` parameter that zeros masked positions before the EMA recurrence. This prevents TimestepNorm-normalized padding from contaminating the EMA state. Additionally, `h_last` is extracted at the last valid position per batch item (not the absolute end); fully masked rows preserve the incoming state, ensuring cached state matches unbatched processing. This matches the JAX reference implementation.
+**Status: ALIGNED.** `ComplexEMA.forward` accepts a `mask` parameter that zeros masked positions before the EMA recurrence. This prevents TimestepNorm-normalized padding from contaminating the EMA state. Additionally, `h_last` is extracted at the last valid position per batch item (not the absolute end); fully masked rows preserve the incoming state, ensuring cached state matches unbatched processing. Chunked attention rejects fully masked rows (all-zero masks) to avoid NaNs in softmax. This matches the JAX reference implementation for CEMA.
 
 ### Attention value/gate path (Equations 16, 18, 20)
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -91,7 +91,7 @@ A pure-Python Kahan cumsum was tested but is ~10x slower due to the loop; not vi
 
 ### CEMA padding mask handling
 
-**Status: ALIGNED.** `ComplexEMA.forward` accepts a `mask` parameter that zeros masked positions before the EMA recurrence. This prevents TimestepNorm-normalized padding from contaminating the EMA state. Additionally, `h_last` is extracted at the last valid position per batch item (not the absolute end), ensuring cached state matches unbatched processing. This matches the JAX reference implementation.
+**Status: ALIGNED.** `ComplexEMA.forward` accepts a `mask` parameter that zeros masked positions before the EMA recurrence. This prevents TimestepNorm-normalized padding from contaminating the EMA state. Additionally, `h_last` is extracted at the last valid position per batch item (not the absolute end); fully masked rows preserve the incoming state, ensuring cached state matches unbatched processing. This matches the JAX reference implementation.
 
 ### Attention value/gate path (Equations 16, 18, 20)
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -43,7 +43,7 @@ The original CUDA-heavy reference (`third_party/upstream-megalodon`) enforces a 
 
 ### Multi-chunk streaming status (this branch)
 
-- Caches now carry an absolute `position` to keep RoPE offsets continuous across chunks; attention caches are clamped to `max_cache_len` (defaults to `chunk_size`) to bound memory while preserving positions.
+- Caches now carry a mask-aware absolute `position` (valid token count) so RoPE offsets stay continuous across chunks even with padding; attention caches are clamped to `max_cache_len` (defaults to `chunk_size`) to bound memory while preserving positions.
 - Chunked attention remains block-diagonal (per paper); long-range context flows through EMA/TimestepNorm states and global positions rather than cross-chunk KV attention.
 - Training still uses the block-diagonal path; streaming inference is chunk-local by default with optional sliding/unbounded KV when configured. Performance is still limited by the pure-Torch sequential EMA (no fused kernels yet).
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -31,9 +31,9 @@ Guardrails/notes:
 Scope for the multi-chunk work on this branch (single GPU/CPU, pure Torch):
 
 - **Attention layout:** Keep the block-diagonal chunked attention used in training. Streaming decode is chunk-local by default; optional sliding-window attention uses a configurable cache horizon.
-- **RoPE offsets:** Track absolute token positions in the cache so rotary phases advance monotonically even when KV is truncated. Offsets must survive cache eviction.
+- **RoPE offsets:** Track mask-aware absolute positions (valid token count) in the cache so rotary phases advance monotonically even when KV is truncated. Offsets must survive cache eviction.
 - **Stateful norms/EMA:** Continue streaming TimestepNorm and CEMA across segments; caches carry their running statistics/hidden state so chunked decoding matches full-sequence results.
-- **Cache horizon knob:** `max_cache_len` caps retained KV (defaults to `chunk_size`); set it above `chunk_size` for sliding-window attention or use `cache_unbounded=True` to disable clamping.
+- **Cache horizon knob:** `max_cache_len` caps retained KV (defaults to `chunk_size`); values below `chunk_size` are rejected; set it above `chunk_size` for sliding-window attention or use `cache_unbounded=True` to disable clamping.
 - **Training path:** Keep FFT EMA for no-cache training. Provide an opt-in switch to exercise the sequential cached path during tests/benchmarks even if it is slower.
 - **Performance caveat:** Without fused kernels, multi-chunk streaming will be correct but slower (2-5x) than the reference; Triton/CUDA kernels can be added later to close the gap.
 

--- a/docs/ema-implementation.md
+++ b/docs/ema-implementation.md
@@ -28,7 +28,7 @@ When processing batched inputs with variable-length sequences, padding tokens mu
 
 - `ComplexEMA.forward` accepts an optional `mask` parameter shaped `(batch, length)` where `True` marks valid tokens.
 - Masked positions are zeroed **before** the EMA recurrence and omega residual, preventing TimestepNorm-normalized padding values from entering the state.
-- For streaming inference, `h_last` is extracted at the last valid position per batch item (not the absolute last position), ensuring the cached state matches unbatched processing.
+- For streaming inference, `h_last` is extracted at the last valid position per batch item (not the absolute last position); fully masked rows preserve the incoming state, ensuring the cached state matches unbatched processing.
 
 This is critical because TimestepNorm normalizes padding tokens (zeros) to non-zero values using running statistics from valid tokens. Without masking, these non-zero values would pollute the EMA state and break the invariant that batched (padded) processing should yield the same cache as unbatched processing.
 

--- a/docs/long-context-streaming.md
+++ b/docs/long-context-streaming.md
@@ -57,7 +57,7 @@ sequenceDiagram
     participant Cache as KV Cache (window)
     participant State as EMA + TN state
     participant Block as Attn Block
-    Note over Cache: default max_cache_len = chunk_size (chunk-local)<br/>max_cache_len = W => keep last W<br/>cache_unbounded = True => keep all
+    Note over Cache: default max_cache_len = chunk_size (chunk-local; values below chunk_size invalid)<br/>max_cache_len = W => keep last W<br/>cache_unbounded = True => keep all
 
     Loop for each chunk
         Block->>State: TimestepNorm (update running mean/var)
@@ -71,7 +71,7 @@ sequenceDiagram
     end
 ```
 
-- Default behavior clamps KV to one chunk (`max_cache_len = chunk_size`); chunk-local streaming calls can span boundaries and are processed chunk-by-chunk with cache reset at each boundary.
+- Default behavior clamps KV to one chunk (`max_cache_len = chunk_size`; values below `chunk_size` are invalid); chunk-local streaming calls can span boundaries and are processed chunk-by-chunk with cache reset at each boundary.
 - A finite `max_cache_len` above the chunk size enables a sliding window.
 - Setting `cache_unbounded=True` keeps all KV (VRAM grows linearly).
 
@@ -80,21 +80,21 @@ sequenceDiagram
 ```mermaid
 flowchart TD
     subgraph RoPE
-        P0[Position counter] -->|start_index for chunk| R1["RoPE apply(Q,K)"]
+        P0[Position counter (valid tokens)] -->|start_index for chunk| R1["RoPE apply(Q,K)"]
         R1 --> O[Attention]
-        O --> P1[Update position counter]
+        O --> P1[Update position counter (valid tokens)]
     end
 ```
 
-- We track absolute positions so rotary phases remain continuous across chunks, even when KV is trimmed.
+- We track mask-aware absolute positions (valid token count) so rotary phases remain continuous across chunks, even when KV is trimmed.
 
 ## 4) Training vs. Inference
 
 - **Training:** block-diagonal attention per chunk; EMA uses FFT (no cache).
-- **Inference:** sequential EMA; attention is chunk-local by default with optional sliding/unbounded KV; RoPE offset advances with absolute position.
+- **Inference:** sequential EMA; attention is chunk-local by default with optional sliding/unbounded KV; RoPE offset advances with mask-aware absolute position.
 
 ## Defaults and Options
 
 - **Upstream reference:** trims KV to one chunk; enforces `cache_len + seq_len <= chunk_size`.
 - **Paper spirit:** "unlimited" via EMA + stateful norms; KV need not be global.
-- **This repo:** default `max_cache_len = chunk_size` (faithful, chunk-local). Set `max_cache_len` above `chunk_size` for sliding-window attention; use `cache_unbounded=True` to disable clamping.
+- **This repo:** default `max_cache_len = chunk_size` (faithful, chunk-local; values below `chunk_size` are invalid). Set `max_cache_len` above `chunk_size` for sliding-window attention; use `cache_unbounded=True` to disable clamping.

--- a/docs/paper-deviations.md
+++ b/docs/paper-deviations.md
@@ -10,7 +10,7 @@ This repo aims to match the Megalodon paper architecture as closely as possible 
 
 - **No 4D chunk-parallel axis.** The paper's time-parallel "chunk parallelism" is not implemented. Training is intended for a single device; multi-GPU scaling would require cross-rank exchange of EMA/Norm state and sharded KV.
 
-- **Optional sliding/unbounded KV window (opt-in).** Training attention remains block-diagonal per chunk, as in the paper. Streaming inference is chunk-local by default (`max_cache_len = chunk_size`). Set `max_cache_len` above `chunk_size` or `cache_unbounded=True` to enable cross-chunk KV attention; long-range context is still primarily carried by EMA + TimestepNorm state.
+- **Optional sliding/unbounded KV window (opt-in).** Training attention remains block-diagonal per chunk, as in the paper. Streaming inference is chunk-local by default (`max_cache_len = chunk_size`; values below `chunk_size` are rejected). Set `max_cache_len` above `chunk_size` or `cache_unbounded=True` to enable cross-chunk KV attention; long-range context is still primarily carried by EMA + TimestepNorm state.
 
 ## Parameterization / Stability Tweaks
 

--- a/scripts/profile_ops.py
+++ b/scripts/profile_ops.py
@@ -5,8 +5,7 @@ from pathlib import Path
 import torch
 from torch.profiler import ProfilerActivity, profile, record_function, schedule
 
-from megalodon import (MegalodonConfig, MegalodonForCausalLM,
-                       configure_precision)
+from megalodon import MegalodonConfig, MegalodonForCausalLM, configure_precision
 
 
 def build_model(device: torch.device, dtype: torch.dtype) -> MegalodonForCausalLM:

--- a/scripts/profile_ops.py
+++ b/scripts/profile_ops.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import torch
 from torch.profiler import ProfilerActivity, profile, record_function, schedule
 
-from megalodon import MegalodonConfig, MegalodonForCausalLM, configure_precision
+from megalodon import (MegalodonConfig, MegalodonForCausalLM,
+                       configure_precision)
 
 
 def build_model(device: torch.device, dtype: torch.dtype) -> MegalodonForCausalLM:

--- a/src/megalodon/configuration_megalodon.py
+++ b/src/megalodon/configuration_megalodon.py
@@ -271,6 +271,7 @@ class MegalodonConfig(PretrainedConfig):
         self.vocab_size = vocab_size
         self.model_dim = model_dim
         self.num_layers = num_layers
+        self.num_hidden_layers = num_layers  # HF compatibility for generate()
         self.num_heads = num_heads
         self.num_attention_heads = num_heads  # HF compatibility
         self.z_dim = z_dim

--- a/src/megalodon/configuration_megalodon.py
+++ b/src/megalodon/configuration_megalodon.py
@@ -210,6 +210,7 @@ class MegalodonConfig(PretrainedConfig):
         :type chunk_size: int
         :param max_cache_len: Maximum KV length retained during streaming decode.
           If ``None``, defaults to ``chunk_size`` unless ``cache_unbounded=True``.
+          Must be >= ``chunk_size`` when provided.
         :type max_cache_len: Optional[int]
         :param cache_unbounded: Disable KV cache clamping regardless of ``max_cache_len`` (VRAM grows linearly with tokens).
         :type cache_unbounded: bool
@@ -366,6 +367,10 @@ class MegalodonConfig(PretrainedConfig):
             )
         if self.max_cache_len is not None and self.max_cache_len <= 0:
             raise ValueError("`max_cache_len` must be positive when provided.")
+        if self.max_cache_len is not None and self.max_cache_len < self.chunk_size:
+            raise ValueError(
+                "`max_cache_len` must be >= `chunk_size` to preserve causal attention."
+            )
         if self.model_dim % self.norm_num_groups != 0:
             raise ValueError(
                 f"`norm_num_groups` ({self.norm_num_groups}) must divide `model_dim` ({self.model_dim})."

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1387,7 +1387,10 @@ class MegalodonAttention(nn.Module):
         # 2) Complex EMA over channels (B,D,L)
         need_last_state = return_cache or (hx is not None)
         y_cema, h_last = self.cema(
-            x_tn.transpose(1, 2), hx=hx, compute_last_state=need_last_state
+            x_tn.transpose(1, 2),
+            hx=hx,
+            compute_last_state=need_last_state,
+            mask=attn_mask,
         )
         y_cema = y_cema.transpose(1, 2)
 

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1080,7 +1080,8 @@ class ChunkedSelfAttention(nn.Module):
                         mask_tokens = mask_blk
                     if mask_tokens.size(1) != Lk_blk:
                         if mask_tokens.size(1) > Lk_blk:
-                            mask_tokens = mask_tokens[:, :Lk_blk]
+                            # Trim from right to match K/V trimming direction
+                            mask_tokens = mask_tokens[:, -Lk_blk:]
                         else:
                             pad_len = Lk_blk - mask_tokens.size(1)
                             mask_tokens = F.pad(mask_tokens, (0, pad_len), value=1)

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1275,14 +1275,13 @@ class ChunkedSelfAttention(nn.Module):
                     # Enforce chunk-local attention by resetting KV at chunk boundaries.
                     # Per-batch positions: pos_in_chunk is (B,) tensor
                     pos_in_chunk = cur_pos % self.chunk_size
-                    # Check if ALL batches are at chunk boundary (simplification)
-                    # For variable-length batches, this is conservative but correct
+                    max_pos_in_chunk = int(pos_in_chunk.max().item())
+                    # Check if ALL batches are at chunk boundary (shared reset)
                     all_at_boundary = (pos_in_chunk == 0).all().item()
                     if all_at_boundary:
                         cur_cache = None
                     elif cur_cache is not None:
                         # Trim cache to max position within chunk across all batches
-                        max_pos_in_chunk = int(pos_in_chunk.max().item())
                         if cur_cache.length > max_pos_in_chunk:
                             cur_cache = AttentionCache(
                                 k=cur_cache.k[:, -max_pos_in_chunk:],
@@ -1292,9 +1291,31 @@ class ChunkedSelfAttention(nn.Module):
                                 if cur_cache.mask is not None
                                 else None,
                             )
-                    # Use minimum position within chunk to determine chunk_len
-                    min_pos_in_chunk = int(pos_in_chunk.min().item())
-                    chunk_len = min(remaining, self.chunk_size - min_pos_in_chunk)
+                        if cur_cache.length > 0:
+                            keep_counts = pos_in_chunk.clamp(max=cur_cache.length)
+                            idx = torch.arange(
+                                cur_cache.length, device=device
+                            ).unsqueeze(0)
+                            chunk_mask = idx >= (
+                                cur_cache.length - keep_counts
+                            ).unsqueeze(1)
+                            if cur_cache.mask is None:
+                                if not chunk_mask.all():
+                                    cur_cache = AttentionCache(
+                                        k=cur_cache.k,
+                                        v=cur_cache.v,
+                                        count=cur_cache.count,
+                                        mask=chunk_mask,
+                                    )
+                            else:
+                                cur_cache = AttentionCache(
+                                    k=cur_cache.k,
+                                    v=cur_cache.v,
+                                    count=cur_cache.count,
+                                    mask=cur_cache.mask & chunk_mask,
+                                )
+                    # Use maximum position within chunk to determine chunk_len
+                    chunk_len = min(remaining, self.chunk_size - max_pos_in_chunk)
                 else:
                     chunk_len = (
                         min(remaining, self.chunk_size)

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -991,6 +991,15 @@ class ChunkedSelfAttention(nn.Module):
             cache_limit = self.chunk_size
         else:
             cache_limit = max_cache_len
+
+        # Validate: max_cache_len must be >= chunk_size to preserve causality
+        if cache_limit is not None and cache_limit < self.chunk_size:
+            raise ValueError(
+                f"max_cache_len ({cache_limit}) must be >= chunk_size "
+                f"({self.chunk_size}). Smaller values would break causal "
+                f"attention within chunks by removing keys that queries need."
+            )
+
         cache = _clamp_attn_cache(cache, cache_limit)
         faithful_chunk_local = (not cache_unbounded) and (
             cache_limit == self.chunk_size

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -785,9 +785,7 @@ class AttentionCache:
 
     k: Tensor  # (B, Lc, H, Dh)
     v: Tensor  # (B, Lc, H, Dv)
-    count: (
-        Tensor  # (B,) total tokens seen per batch item (for absolute position indexing)
-    )
+    count: Tensor  # (B,) total valid tokens seen per batch item (mask-aware positions)
     mask: Optional[Tensor] = None  # (B, Lc) - True for valid, False for padded
 
     @property
@@ -797,8 +795,12 @@ class AttentionCache:
 
     @property
     def start_index(self) -> Tensor:
-        """Absolute position of the first cached token per batch item."""
-        return self.count - self.length
+        """Absolute position of the first *valid* cached token per batch item."""
+        if self.mask is None:
+            valid_len = self.length
+        else:
+            valid_len = self.mask.to(torch.long).sum(dim=1)
+        return self.count - valid_len
 
 
 def _clamp_attn_cache(
@@ -875,7 +877,7 @@ class LayerCache:
     norm: Optional[NormState] = None
     ema: Optional[Tensor] = None
     position: Optional[Tensor] = (
-        None  # (B,) absolute token position for RoPE per batch item
+        None  # (B,) absolute position cursor (valid token count) for RoPE per batch item
     )
 
 
@@ -1022,6 +1024,8 @@ class ChunkedSelfAttention(nn.Module):
         B, L, H, Dh = q.shape
         Dv = v.size(-1)
         device = q.device
+        if attn_mask is not None:
+            attn_mask = attn_mask.to(dtype=torch.bool)
         if cache_unbounded:
             cache_limit = None
         elif max_cache_len is None or max_cache_len == -1:
@@ -1038,6 +1042,17 @@ class ChunkedSelfAttention(nn.Module):
             )
 
         cache = _clamp_attn_cache(cache, cache_limit)
+        if position_ids is None and attn_mask is not None:
+            if cache is not None:
+                start_pos = cache.count
+            else:
+                start_pos = torch.full(
+                    (B,), start_index, dtype=torch.long, device=device
+                )
+            mask_long = attn_mask.to(torch.long)
+            pos_offsets = mask_long.cumsum(dim=1) - 1
+            pos_offsets = pos_offsets.clamp(min=0)
+            position_ids = start_pos.unsqueeze(1) + pos_offsets
         faithful_chunk_local = (not cache_unbounded) and (
             cache_limit == self.chunk_size
         )
@@ -1082,7 +1097,6 @@ class ChunkedSelfAttention(nn.Module):
             B_, L_, H_, Dh_ = q_blk.shape
             # Build position_ids for RoPE from per-batch start positions
             if position_ids_blk is None:
-                # start_pos is (B,), build (B, L_) position indices
                 offsets = torch.arange(L_, device=device, dtype=torch.long)
                 position_ids_blk = start_pos.unsqueeze(1) + offsets.unsqueeze(0)
             # Rotate only the new block, then concatenate with already-rotated cache.
@@ -1092,17 +1106,13 @@ class ChunkedSelfAttention(nn.Module):
             if cache_blk is not None:
                 k_cat = torch.cat([cache_blk.k, k_blk], dim=1)
                 v_cat = torch.cat([cache_blk.v, v_blk], dim=1)
-                prefix_start = cache_blk.start_index
             else:
                 k_cat = k_blk
                 v_cat = v_blk
-                prefix_start = start_pos
             keep = (
                 k_cat.size(1) if keep_limit is None else min(keep_limit, k_cat.size(1))
             )
             if keep_limit is not None and k_cat.size(1) > keep:
-                dropped = k_cat.size(1) - keep
-                prefix_start = prefix_start + dropped
                 k_cat = k_cat[:, -keep:]
                 v_cat = v_cat[:, -keep:]
             Lk_blk = k_cat.size(1)
@@ -1110,17 +1120,60 @@ class ChunkedSelfAttention(nn.Module):
             k_ = k_cat.transpose(1, 2)  # (B,H,Lk,Dh)
             v_ = v_cat.transpose(1, 2)  # (B,H,Lk,Dv)
 
+            mask_tokens = None
+            has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
+            has_current_mask = mask_blk is not None
+            if has_prefix_mask or has_current_mask:
+                if cache_blk is not None and cache_blk.length > 0:
+                    if has_prefix_mask:
+                        prefix_mask = cache_blk.mask
+                    else:
+                        prefix_mask = q_blk.new_ones(
+                            B_, cache_blk.length, dtype=torch.bool
+                        )
+                else:
+                    prefix_mask = None
+                if has_current_mask:
+                    current_mask = mask_blk.to(torch.bool)
+                else:
+                    current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
+                if prefix_mask is not None:
+                    mask_tokens = torch.cat([prefix_mask, current_mask], dim=1)
+                else:
+                    mask_tokens = current_mask
+                if mask_tokens.size(1) > Lk_blk:
+                    mask_tokens = mask_tokens[:, -Lk_blk:]
+                elif mask_tokens.size(1) < Lk_blk:
+                    pad_len = Lk_blk - mask_tokens.size(1)
+                    mask_tokens = F.pad(mask_tokens, (pad_len, 0), value=1)
+
+            if cache_blk is not None:
+                if cache_blk.mask is None:
+                    cache_offset = cache_blk.count - cache_blk.length
+                    cache_positions = cache_offset.unsqueeze(1) + torch.arange(
+                        cache_blk.length, device=device
+                    ).unsqueeze(0)
+                else:
+                    cache_mask_long = cache_blk.mask.to(torch.long)
+                    cache_valid = cache_mask_long.sum(dim=1)
+                    cache_offset = cache_blk.count - cache_valid
+                    cache_positions = cache_mask_long.cumsum(dim=1) - 1
+                    cache_positions = cache_positions.clamp(min=0)
+                    cache_positions = cache_offset.unsqueeze(1) + cache_positions
+                key_positions = torch.cat(
+                    [cache_positions, position_ids_blk.to(torch.long)], dim=1
+                )
+            else:
+                key_positions = position_ids_blk.to(torch.long)
+            if key_positions.size(1) > Lk_blk:
+                key_positions = key_positions[:, -Lk_blk:]
+
             base_mask = None
             prefix_len_blk = max(0, Lk_blk - L_)  # trimmed cache length
             # Only build explicit mask when we have prefix cache or padding mask.
             # SDPA is_causal=True handles causality correctly regardless of absolute position.
-            if prefix_len_blk > 0 or mask_blk is not None:
-                # Per-batch positions: prefix_start and start_pos are (B,) tensors
-                # key_positions: (B, Lk), query_positions: (B, L)
-                key_offsets = torch.arange(Lk_blk, device=device)  # (Lk,)
-                key_positions = prefix_start.unsqueeze(1) + key_offsets.unsqueeze(0)
-                query_offsets = torch.arange(L_, device=device)  # (L,)
-                query_positions = start_pos.unsqueeze(1) + query_offsets.unsqueeze(0)
+            if prefix_len_blk > 0 or mask_tokens is not None:
+                query_positions = position_ids_blk.to(torch.long)
                 # causal: (B, L, Lk) - key_positions <= query_positions
                 causal = key_positions.unsqueeze(1) <= query_positions.unsqueeze(2)
                 base_mask = torch.where(
@@ -1129,47 +1182,41 @@ class ChunkedSelfAttention(nn.Module):
                     torch.tensor(float("-inf"), dtype=q_.dtype, device=device),
                 )
                 base_mask = base_mask.unsqueeze(1)  # (B, 1, L, Lk)
-                # Apply padding mask when cache has mask OR current has mask
-                has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
-                has_current_mask = mask_blk is not None
-                if has_prefix_mask or has_current_mask:
-                    # Build prefix mask (for cached tokens)
-                    if prefix_len_blk > 0:
-                        if has_prefix_mask:
-                            prefix_mask = cache_blk.mask
-                        else:
-                            # Cache has no mask, assume all valid
-                            prefix_mask = q_blk.new_ones(
-                                B_, prefix_len_blk, dtype=torch.bool
-                            )
-                    else:
-                        prefix_mask = None
-
-                    # Build current mask (for new tokens)
-                    if has_current_mask:
-                        current_mask = mask_blk
-                    else:
-                        # No current mask, assume all valid
-                        current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
-
-                    # Concatenate prefix + current
-                    if prefix_mask is not None:
-                        mask_tokens = torch.cat([prefix_mask, current_mask], dim=1)
-                    else:
-                        mask_tokens = current_mask
-
-                    # Align mask to K/V length (right-aligned trimming)
-                    if mask_tokens.size(1) != Lk_blk:
-                        if mask_tokens.size(1) > Lk_blk:
-                            # Trim from right to match K/V trimming direction
-                            mask_tokens = mask_tokens[:, -Lk_blk:]
-                        else:
-                            pad_len = Lk_blk - mask_tokens.size(1)
-                            mask_tokens = F.pad(mask_tokens, (0, pad_len), value=1)
+                if mask_tokens is not None:
                     base_mask = base_mask.masked_fill(
                         (mask_tokens == 0).view(B_, 1, 1, Lk_blk), float("-inf")
                     )
                 # Keep mask as (B_,1,L_,Lk_blk) or (1,1,L_,Lk_blk) - SDPA broadcasts
+
+            # Guard against fully-masked sequences: if any VALID query has no valid keys,
+            # softmax would produce NaN (all -inf logits -> 0/0 in softmax)
+            # Note: Padded query positions may have no valid keys, but that's fine
+            # because their outputs are ignored anyway.
+            if base_mask is not None:
+                # Check if any row (query position) has all -inf values
+                # base_mask: (B_, 1, L_, Lk_blk) - check across last dim
+                has_valid_key = (base_mask > float("-inf")).any(dim=-1)  # (B_, 1, L_)
+
+                # Build query validity mask: which query positions need valid keys?
+                # Only non-padded (valid) query positions must have at least one valid key
+                if mask_blk is not None:
+                    query_is_valid = mask_blk.bool()  # (B_, L_)
+                else:
+                    # No mask means all queries are valid
+                    query_is_valid = torch.ones(B_, L_, dtype=torch.bool, device=device)
+
+                # Check: for every valid query, must have at least one valid key
+                # has_valid_key: (B_, 1, L_) -> squeeze to (B_, L_)
+                # Only check positions where query_is_valid is True
+                valid_queries_have_keys = ~query_is_valid | has_valid_key.squeeze(
+                    1
+                )  # (B_, L_)
+                if not valid_queries_have_keys.all():
+                    raise ValueError(
+                        "Fully-masked sequences detected: some non-padded query positions "
+                        "have no valid keys to attend to. This would produce NaN in softmax. "
+                        "Ensure at least one valid token exists for each valid query position."
+                    )
 
             if self._sdpa_available:
                 is_causal = base_mask is None
@@ -1185,39 +1232,12 @@ class ChunkedSelfAttention(nn.Module):
             else:
                 scores = torch.matmul(q_, k_.transpose(-2, -1))
                 scores = scores.float()
-                scores = scores + self._causal_mask(
-                    L_, Lk_blk, device, torch.float32, offset=prefix_len_blk
-                )
-
-                # Apply padding mask when cache has mask OR current has mask
-                has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
-                has_current_mask = mask_blk is not None
-                if has_prefix_mask or has_current_mask:
-                    # Build prefix mask (for cached tokens)
-                    if prefix_len_blk > 0:
-                        if has_prefix_mask:
-                            prefix_mask = cache_blk.mask
-                        else:
-                            prefix_mask = q_blk.new_ones(
-                                B_, prefix_len_blk, dtype=torch.bool
-                            )
-                    else:
-                        prefix_mask = None
-
-                    # Build current mask (for new tokens)
-                    if has_current_mask:
-                        current_mask = mask_blk
-                    else:
-                        current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
-
-                    # Concatenate prefix + current
-                    if prefix_mask is not None:
-                        mask = torch.cat([prefix_mask, current_mask], dim=1)
-                    else:
-                        mask = current_mask
-
-                    pad = (mask.to(torch.float32) - 1.0) * 1e9
-                    scores = scores + pad.unsqueeze(1).unsqueeze(2)
+                if base_mask is not None:
+                    scores = scores + base_mask.to(scores.dtype)
+                else:
+                    scores = scores + self._causal_mask(
+                        L_, Lk_blk, device, torch.float32, offset=prefix_len_blk
+                    )
 
                 attn = torch.softmax(scores, dim=-1).to(q_)
                 attn = F.dropout(attn, p=self.attention_dropout, training=training)
@@ -1225,40 +1245,14 @@ class ChunkedSelfAttention(nn.Module):
 
             out_blk = out_blk.transpose(1, 2)  # (B,L,H,Dv)
 
-            total = (cache_blk.count if cache_blk is not None else start_pos) + L_
-            # Build mask for new cache by concatenating cached + current masks
-            has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
-            has_current_mask = mask_blk is not None
-            has_cache = cache_blk is not None
-            prefix_len = cache_blk.length if cache_blk is not None else 0
-
-            if has_prefix_mask or has_current_mask:
-                # Build prefix mask (for cached tokens)
-                if has_prefix_mask:
-                    prefix_mask = cache_blk.mask
-                elif has_cache and prefix_len > 0:
-                    # Cache exists but has no mask - assume all cached tokens are valid
-                    prefix_mask = q_blk.new_ones(B_, prefix_len, dtype=torch.bool)
-                else:
-                    prefix_mask = None
-
-                # Build current mask (all-ones if not provided)
-                if has_current_mask:
-                    current_mask = mask_blk
-                else:
-                    current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
-
-                # Concatenate
-                if prefix_mask is not None:
-                    mask_cat = torch.cat([prefix_mask, current_mask], dim=1)
-                else:
-                    mask_cat = current_mask
-
-                new_mask = mask_cat[:, -keep:] if mask_cat.size(1) > keep else mask_cat
+            if mask_blk is not None:
+                valid_counts = mask_blk.to(torch.long).sum(dim=1)
             else:
-                new_mask = None
+                valid_counts = torch.full((B_,), L_, dtype=torch.long, device=device)
+            base_count = cache_blk.count if cache_blk is not None else start_pos
+            total = base_count + valid_counts
             new_cache_blk = AttentionCache(
-                k=k_cat[:, -keep:], v=v_cat[:, -keep:], count=total, mask=new_mask
+                k=k_cat[:, -keep:], v=v_cat[:, -keep:], count=total, mask=mask_tokens
             )
 
             out_blk = out_blk.reshape(B_, L_, H_ * Dv)
@@ -1448,10 +1442,17 @@ class ChunkedSelfAttention(nn.Module):
             out = torch.cat(outs, dim=1).reshape(B, L, H * Dv)
         if pad_len:
             out = out[:, :orig_L, :]
-        # Convert final_pos to per-batch tensor
-        final_pos = torch.full(
-            (B,), start_index + orig_L, dtype=torch.long, device=device
-        )
+        # Convert final_pos to per-batch tensor (mask-aware when provided)
+        if attn_mask is None:
+            final_pos = torch.full(
+                (B,), start_index + orig_L, dtype=torch.long, device=device
+            )
+        else:
+            valid_counts = attn_mask.to(torch.long).sum(dim=1)
+            final_pos = (
+                torch.full((B,), start_index, dtype=torch.long, device=device)
+                + valid_counts
+            )
         if return_position:
             return out, None, final_pos
         return out, None
@@ -1909,6 +1910,16 @@ class MegalodonModel(PreTrainedModel):
         # Normalize attention mask to bool for consistent semantics
         if attention_mask is not None:
             attention_mask = attention_mask.to(dtype=torch.bool)
+            if past_key_values is not None and attention_mask.size(1) != input_ids.size(
+                1
+            ):
+                if attention_mask.size(1) < input_ids.size(1):
+                    raise ValueError(
+                        "attention_mask length must match input_ids when using past_key_values."
+                    )
+                attention_mask = attention_mask[:, -input_ids.size(1) :]
+            if attention_mask.all().item():
+                attention_mask = None
 
         x = self.embed(input_ids) * self.scale
         if max_cache_len == -1:

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1077,16 +1077,36 @@ class ChunkedSelfAttention(nn.Module):
                     torch.tensor(float("-inf"), dtype=q_.dtype, device=device),
                 )
                 base_mask = base_mask.view(1, L_, Lk_blk).unsqueeze(1)  # (1,1,L,Lk)
-                if mask_blk is not None:
+                # Apply padding mask when cache has mask OR current has mask
+                has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
+                has_current_mask = mask_blk is not None
+                if has_prefix_mask or has_current_mask:
+                    # Build prefix mask (for cached tokens)
                     if prefix_len_blk > 0:
-                        # Use stored mask from cache if available, else assume all valid
-                        if cache_blk is not None and cache_blk.mask is not None:
+                        if has_prefix_mask:
                             prefix_mask = cache_blk.mask
                         else:
-                            prefix_mask = mask_blk.new_ones(B_, prefix_len_blk)
-                        mask_tokens = torch.cat([prefix_mask, mask_blk], dim=1)
+                            # Cache has no mask, assume all valid
+                            prefix_mask = q_blk.new_ones(
+                                B_, prefix_len_blk, dtype=torch.bool
+                            )
                     else:
-                        mask_tokens = mask_blk
+                        prefix_mask = None
+
+                    # Build current mask (for new tokens)
+                    if has_current_mask:
+                        current_mask = mask_blk
+                    else:
+                        # No current mask, assume all valid
+                        current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
+
+                    # Concatenate prefix + current
+                    if prefix_mask is not None:
+                        mask_tokens = torch.cat([prefix_mask, current_mask], dim=1)
+                    else:
+                        mask_tokens = current_mask
+
+                    # Align mask to K/V length (right-aligned trimming)
                     if mask_tokens.size(1) != Lk_blk:
                         if mask_tokens.size(1) > Lk_blk:
                             # Trim from right to match K/V trimming direction
@@ -1117,16 +1137,33 @@ class ChunkedSelfAttention(nn.Module):
                     L_, Lk_blk, device, torch.float32, offset=prefix_len_blk
                 )
 
-                if mask_blk is not None:
+                # Apply padding mask when cache has mask OR current has mask
+                has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
+                has_current_mask = mask_blk is not None
+                if has_prefix_mask or has_current_mask:
+                    # Build prefix mask (for cached tokens)
                     if prefix_len_blk > 0:
-                        # Use stored mask from cache if available, else assume all valid
-                        if cache_blk is not None and cache_blk.mask is not None:
+                        if has_prefix_mask:
                             prefix_mask = cache_blk.mask
                         else:
-                            prefix_mask = mask_blk.new_ones(B_, prefix_len_blk)
-                        mask = torch.cat([prefix_mask, mask_blk], dim=1)
+                            prefix_mask = q_blk.new_ones(
+                                B_, prefix_len_blk, dtype=torch.bool
+                            )
                     else:
-                        mask = mask_blk
+                        prefix_mask = None
+
+                    # Build current mask (for new tokens)
+                    if has_current_mask:
+                        current_mask = mask_blk
+                    else:
+                        current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
+
+                    # Concatenate prefix + current
+                    if prefix_mask is not None:
+                        mask = torch.cat([prefix_mask, current_mask], dim=1)
+                    else:
+                        mask = current_mask
+
                     pad = (mask.to(torch.float32) - 1.0) * 1e9
                     scores = scores + pad.unsqueeze(1).unsqueeze(2)
 
@@ -1138,16 +1175,36 @@ class ChunkedSelfAttention(nn.Module):
 
             total = (cache_blk.count if cache_blk is not None else start_pos) + L_
             # Build mask for new cache by concatenating cached + current masks
-            if mask_blk is not None:
-                if cache_blk is not None and cache_blk.mask is not None:
-                    mask_cat = torch.cat([cache_blk.mask, mask_blk], dim=1)
+            has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
+            has_current_mask = mask_blk is not None
+            has_cache = cache_blk is not None
+            prefix_len = cache_blk.length if cache_blk is not None else 0
+
+            if has_prefix_mask or has_current_mask:
+                # Build prefix mask (for cached tokens)
+                if has_prefix_mask:
+                    prefix_mask = cache_blk.mask
+                elif has_cache and prefix_len > 0:
+                    # Cache exists but has no mask - assume all cached tokens are valid
+                    prefix_mask = q_blk.new_ones(B_, prefix_len, dtype=torch.bool)
                 else:
-                    mask_cat = mask_blk
+                    prefix_mask = None
+
+                # Build current mask (all-ones if not provided)
+                if has_current_mask:
+                    current_mask = mask_blk
+                else:
+                    current_mask = q_blk.new_ones(B_, L_, dtype=torch.bool)
+
+                # Concatenate
+                if prefix_mask is not None:
+                    mask_cat = torch.cat([prefix_mask, current_mask], dim=1)
+                else:
+                    mask_cat = current_mask
+
                 new_mask = mask_cat[:, -keep:] if mask_cat.size(1) > keep else mask_cat
             else:
-                new_mask = cache_blk.mask if cache_blk is not None else None
-                if new_mask is not None and new_mask.size(1) > keep:
-                    new_mask = new_mask[:, -keep:]
+                new_mask = None
             new_cache_blk = AttentionCache(
                 k=k_cat[:, -keep:], v=v_cat[:, -keep:], count=total, mask=new_mask
             )

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -46,7 +46,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from transformers import PreTrainedModel
+from transformers import GenerationMixin, PreTrainedModel
 from transformers.modeling_outputs import (
     BaseModelOutputWithPast,
     CausalLMOutputWithPast,
@@ -1938,20 +1938,46 @@ class MegalodonModel(PreTrainedModel):
         if past_key_values is None:
             caches = [None] * len(self.layers)
         else:
-            pkv_list = list(past_key_values)
-            if len(pkv_list) > len(self.layers):
-                past_final_norm = pkv_list.pop()
-                if past_final_norm is not None and not isinstance(
-                    past_final_norm, NormState
+            # Check if this is an HF-managed cache (e.g., DynamicCache) vs our LayerCache format
+            # HF's caches are not compatible with Megalodon's streaming cache, so we skip them
+            # and let the model manage its own cache
+            try:
+                pkv_list = list(past_key_values)
+            except (TypeError, AttributeError):
+                # Not iterable or not our cache format - ignore and use fresh cache
+                caches = [None] * len(self.layers)
+                past_key_values = None
+                cache_enabled = use_cache
+                pkv_list = []
+
+            # Check if the first non-None item is a LayerCache
+            if pkv_list:
+                first_item = next((x for x in pkv_list if x is not None), None)
+                if first_item is not None and not isinstance(
+                    first_item, (LayerCache, NormState)
                 ):
-                    raise TypeError(
-                        f"Expected final cache entry to be NormState, got {type(past_final_norm).__name__}"
-                    )
-            caches = [
-                _clamp_layer_cache(c, cache_limit) for c in pkv_list[: len(self.layers)]
-            ]
-            if len(caches) < len(self.layers):
-                caches.extend([None] * (len(self.layers) - len(caches)))
+                    # Incompatible cache type (e.g., HF DynamicCache, tuple, etc.)
+                    # Fall back to fresh cache
+                    caches = [None] * len(self.layers)
+                    pkv_list = []
+
+            if pkv_list:
+                if len(pkv_list) > len(self.layers):
+                    past_final_norm = pkv_list.pop()
+                    if past_final_norm is not None and not isinstance(
+                        past_final_norm, NormState
+                    ):
+                        raise TypeError(
+                            f"Expected final cache entry to be NormState, got {type(past_final_norm).__name__}"
+                        )
+                caches = [
+                    _clamp_layer_cache(c, cache_limit)
+                    for c in pkv_list[: len(self.layers)]
+                ]
+                if len(caches) < len(self.layers):
+                    caches.extend([None] * (len(self.layers) - len(caches)))
+            else:
+                caches = [None] * len(self.layers)
         all_hidden = [] if output_hidden_states else None
 
         for i, layer in enumerate(self.layers):
@@ -2024,7 +2050,7 @@ class MegalodonModel(PreTrainedModel):
         )
 
 
-class MegalodonForCausalLM(PreTrainedModel):
+class MegalodonForCausalLM(PreTrainedModel, GenerationMixin):
     """Megalodon decoder with tied LM head for causal language modeling."""
 
     config_class = MegalodonConfig
@@ -2181,6 +2207,124 @@ class MegalodonForCausalLM(PreTrainedModel):
         if loss is not None:
             out = (loss,) + out
         return out
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids: torch.LongTensor,
+        past_key_values: Optional[List[Optional[LayerCache]]] = None,
+        attention_mask: Optional[Tensor] = None,
+        **kwargs,
+    ) -> dict:
+        """Prepare model inputs for generation.
+
+        When ``past_key_values`` is provided, only the last token of ``input_ids``
+        is used (incremental decoding).
+
+        :param input_ids: Token ids shaped ``(batch, length)``.
+        :type input_ids: torch.LongTensor
+        :param past_key_values: Optional cache from a previous generation step.
+        :type past_key_values: Optional[List[Optional[LayerCache]]]
+        :param attention_mask: Optional attention mask.
+        :type attention_mask: Optional[Tensor]
+        :param kwargs: Additional keyword arguments passed through.
+        :returns: Dictionary of model inputs for the forward pass.
+        :rtype: dict
+        """
+        if past_key_values is not None:
+            # Incremental decoding: only use the last token
+            input_ids = input_ids[:, -1:]
+            # Extend attention mask if provided
+            if attention_mask is not None:
+                attention_mask = attention_mask[:, -1:]
+
+        return {
+            "input_ids": input_ids,
+            "past_key_values": past_key_values,
+            "attention_mask": attention_mask,
+            "use_cache": kwargs.get("use_cache", True),
+        }
+
+    @staticmethod
+    def _reorder_cache(
+        past_key_values: tuple,
+        beam_idx: torch.LongTensor,
+    ) -> tuple:
+        """Reorder cache for beam search.
+
+        When using beam search, the batch dimension of the cache needs to be
+        reordered to match the selected beam indices at each step.
+
+        :param past_key_values: Tuple containing LayerCache objects plus optional
+            final NormState from previous step.
+        :type past_key_values: tuple
+        :param beam_idx: Indices selecting which beams to keep, shape ``(batch,)``.
+        :type beam_idx: torch.LongTensor
+        :returns: Reordered cache tuple.
+        :rtype: tuple
+        """
+        reordered = []
+        for item in past_key_values:
+            if item is None:
+                reordered.append(None)
+                continue
+
+            # Handle NormState (final norm state, not inside LayerCache)
+            if isinstance(item, NormState):
+                reordered.append(
+                    NormState(
+                        count=item.count.index_select(0, beam_idx),
+                        mean=item.mean.index_select(0, beam_idx),
+                        var=item.var.index_select(0, beam_idx),
+                    )
+                )
+                continue
+
+            # Handle LayerCache
+            layer_cache = item
+
+            # Reorder attention cache
+            new_attn = None
+            if layer_cache.attn is not None:
+                attn = layer_cache.attn
+                new_attn = AttentionCache(
+                    k=attn.k.index_select(0, beam_idx),
+                    v=attn.v.index_select(0, beam_idx),
+                    count=attn.count.index_select(0, beam_idx),
+                    mask=attn.mask.index_select(0, beam_idx)
+                    if attn.mask is not None
+                    else None,
+                )
+
+            # Reorder norm state inside LayerCache
+            new_norm = None
+            if layer_cache.norm is not None:
+                norm = layer_cache.norm
+                new_norm = NormState(
+                    count=norm.count.index_select(0, beam_idx),
+                    mean=norm.mean.index_select(0, beam_idx),
+                    var=norm.var.index_select(0, beam_idx),
+                )
+
+            # Reorder EMA state
+            new_ema = None
+            if layer_cache.ema is not None:
+                new_ema = layer_cache.ema.index_select(0, beam_idx)
+
+            # Reorder position
+            new_position = None
+            if layer_cache.position is not None:
+                new_position = layer_cache.position.index_select(0, beam_idx)
+
+            reordered.append(
+                LayerCache(
+                    attn=new_attn,
+                    norm=new_norm,
+                    ema=new_ema,
+                    position=new_position,
+                )
+            )
+
+        return tuple(reordered)
 
 
 __all__ = [

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1331,6 +1331,9 @@ class ChunkedSelfAttention(nn.Module):
             v = F.pad(v, (0, 0, 0, 0, 0, pad_len))
             if attn_mask is not None:
                 attn_mask = F.pad(attn_mask, (0, pad_len), value=0)
+            if position_ids is not None:
+                pad_values = position_ids[:, -1:].expand(B, pad_len)
+                position_ids = torch.cat([position_ids, pad_values], dim=1)
             L = q.size(1)
 
         # Single-block path (non-streaming or already chunked)

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1043,6 +1043,18 @@ class ChunkedSelfAttention(nn.Module):
             )
 
         cache = _clamp_attn_cache(cache, cache_limit)
+        if L == 0:
+            empty_out = q.new_zeros((B, 0, H * Dv))
+            result_cache = cache if return_cache else None
+            if return_position:
+                if cache is not None:
+                    cur_pos = cache.count
+                else:
+                    cur_pos = torch.full(
+                        (B,), start_index, dtype=torch.long, device=device
+                    )
+                return empty_out, result_cache, cur_pos
+            return empty_out, result_cache
         if position_ids is None and attn_mask is not None:
             if cache is not None:
                 start_pos = cache.count

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -184,25 +184,31 @@ class RotaryEmbedding(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def _get_cis(
-        self, start: int, length: int, device: torch.device, dtype: torch.dtype
+        self,
+        positions: Tensor,
+        device: torch.device,
+        dtype: torch.dtype,
     ) -> Tuple[Tensor, Tensor]:
-        """Return cosine and sine tables starting at ``start`` for ``length`` steps.
+        """Return cosine and sine tables for given positions.
 
-        :param start: Offset into the cached rotary angles.
-        :type start: int
-        :param length: Number of consecutive positions to materialize.
-        :type length: int
+        :param positions: Position indices, shape ``(length,)`` or ``(batch, length)``.
+        :type positions: Tensor
         :param device: Device to place the resulting tensors on.
         :type device: torch.device
         :param dtype: Target dtype for the cosine/sine tables.
         :type dtype: torch.dtype
-        :returns: Cosine and sine tensors of shape ``(length, dim/2)``.
+        :returns: Cosine and sine tensors matching position shape + ``(dim/2,)``.
         :rtype: Tuple[Tensor, Tensor]
         """
-        positions = torch.arange(
-            start, start + length, dtype=torch.float32, device=device
-        )
-        angles = positions.unsqueeze(1) * self.inv_freq.unsqueeze(0)
+        # positions: (L,) or (B, L)
+        # inv_freq: (Dh/2,)
+        # angles: (L, Dh/2) or (B, L, Dh/2)
+        positions_float = positions.to(dtype=torch.float32, device=device)
+        if positions_float.dim() == 1:
+            angles = positions_float.unsqueeze(1) * self.inv_freq.unsqueeze(0)
+        else:
+            # (B, L) @ (1, 1, Dh/2) -> (B, L, Dh/2)
+            angles = positions_float.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)
         return torch.cos(angles).to(dtype), torch.sin(angles).to(dtype)
 
     @staticmethod
@@ -217,28 +223,50 @@ class RotaryEmbedding(nn.Module):
         return torch.cat([x.real, x.imag], dim=-1)
 
     def forward(
-        self, q: Tensor, k: Tensor, start_index: int = 0
+        self,
+        q: Tensor,
+        k: Tensor,
+        start_index: int = 0,
+        position_ids: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor]:
-        """Rotate per-head ``q`` and ``k`` vectors starting at ``start_index``.
+        """Rotate per-head ``q`` and ``k`` vectors.
 
         :param q: Query tensor shaped ``(batch, time, heads, dim)``.
         :type q: Tensor
         :param k: Key tensor shaped ``(batch, time, heads, dim)``.
         :type k: Tensor
-        :param start_index: Absolute position offset for the rotary phase.
+        :param start_index: Absolute position offset for the rotary phase (used when
+            ``position_ids`` is None). Defaults to 0.
         :type start_index: int
+        :param position_ids: Per-position indices, shape ``(batch, time)``. When
+            provided, overrides ``start_index`` for per-sample position control
+            (e.g., with left-padding).
+        :type position_ids: Optional[Tensor]
         :returns: Tuple of rotated ``(q, k)`` tensors.
         :rtype: Tuple[Tensor, Tensor]
-        :raises ValueError: If ``start_index`` is negative.
+        :raises ValueError: If ``start_index`` is negative when ``position_ids`` is None.
         """
-        if start_index < 0:
-            raise ValueError(
-                f"start_index must be non-negative for RoPE, got {start_index}."
-            )
         B, T, H, Dh = q.shape
-        cos, sin = self._get_cis(start_index, T, q.device, q.dtype)  # (T, Dh/2)
-        cos = cos.unsqueeze(0).unsqueeze(2)  # (1, T, 1, Dh/2)
-        sin = sin.unsqueeze(0).unsqueeze(2)  # (1, T, 1, Dh/2)
+
+        if position_ids is not None:
+            # Per-batch positions provided
+            positions = position_ids  # (B, T)
+            cos, sin = self._get_cis(positions, q.device, q.dtype)  # (B, T, Dh/2)
+            cos = cos.unsqueeze(2)  # (B, T, 1, Dh/2)
+            sin = sin.unsqueeze(2)  # (B, T, 1, Dh/2)
+        else:
+            # Scalar start_index (backward compatible)
+            if start_index < 0:
+                raise ValueError(
+                    f"start_index must be non-negative for RoPE, got {start_index}."
+                )
+            positions = torch.arange(
+                start_index, start_index + T, dtype=torch.long, device=q.device
+            )
+            cos, sin = self._get_cis(positions, q.device, q.dtype)  # (T, Dh/2)
+            cos = cos.unsqueeze(0).unsqueeze(2)  # (1, T, 1, Dh/2)
+            sin = sin.unsqueeze(0).unsqueeze(2)  # (1, T, 1, Dh/2)
+
         q1, q2 = q.chunk(2, dim=-1)
         k1, k2 = k.chunk(2, dim=-1)
         # (a + ib) * (cos + i sin) => rotate pairs
@@ -757,7 +785,9 @@ class AttentionCache:
 
     k: Tensor  # (B, Lc, H, Dh)
     v: Tensor  # (B, Lc, H, Dv)
-    count: int  # total tokens seen (for absolute position indexing)
+    count: (
+        Tensor  # (B,) total tokens seen per batch item (for absolute position indexing)
+    )
     mask: Optional[Tensor] = None  # (B, Lc) - True for valid, False for padded
 
     @property
@@ -766,8 +796,8 @@ class AttentionCache:
         return self.k.size(1)
 
     @property
-    def start_index(self) -> int:
-        """Absolute position of the first cached token in this cache."""
+    def start_index(self) -> Tensor:
+        """Absolute position of the first cached token per batch item."""
         return self.count - self.length
 
 
@@ -844,7 +874,9 @@ class LayerCache:
     attn: Optional[AttentionCache] = None
     norm: Optional[NormState] = None
     ema: Optional[Tensor] = None
-    position: int = 0  # absolute token position for RoPE
+    position: Optional[Tensor] = (
+        None  # (B,) absolute token position for RoPE per batch item
+    )
 
 
 class ChunkedSelfAttention(nn.Module):
@@ -946,9 +978,10 @@ class ChunkedSelfAttention(nn.Module):
         return_cache: bool = False,
         return_position: bool = False,
         cache_unbounded: bool = False,
+        position_ids: Optional[Tensor] = None,
     ) -> (
         Tuple[Tensor, Optional[AttentionCache]]
-        | Tuple[Tensor, Optional[AttentionCache], int]
+        | Tuple[Tensor, Optional[AttentionCache], Tensor]
     ):
         """Compute chunked self-attention and return the result plus cache.
 
@@ -958,7 +991,8 @@ class ChunkedSelfAttention(nn.Module):
         :type k: Tensor
         :param v: Value tensor shaped ``(batch, length, heads, dim_v)``.
         :type v: Tensor
-        :param start_index: Absolute offset for rotary embeddings.
+        :param start_index: Absolute offset for rotary embeddings (used when
+            ``position_ids`` is None).
         :type start_index: int
         :param cache: Optional cached keys/values from previous chunks.
         :type cache: Optional[AttentionCache]
@@ -978,6 +1012,9 @@ class ChunkedSelfAttention(nn.Module):
         :type return_position: bool
         :param cache_unbounded: Disable KV cache clamping (explicit opt-in).
         :type cache_unbounded: bool
+        :param position_ids: Per-position RoPE indices, shape ``(batch, length)``. When
+            provided, overrides ``start_index`` for per-sample position control.
+        :type position_ids: Optional[Tensor]
         :returns: Tuple of attention output and updated cache; includes the new absolute position when ``return_position`` is True.
         :rtype: Tuple[Tensor, Optional[AttentionCache]] or Tuple[Tensor, Optional[AttentionCache], int]
         :raises AssertionError: If ``length`` is not divisible by ``chunk_size`` when processing multi-chunk training batches.
@@ -1009,11 +1046,16 @@ class ChunkedSelfAttention(nn.Module):
             q_blk: Tensor,
             k_blk: Tensor,
             v_blk: Tensor,
-            start_pos: int,
+            start_pos: Tensor,
             cache_blk: Optional[AttentionCache],
             mask_blk: Optional[Tensor],
-        ) -> Tuple[Tensor, Optional[AttentionCache], int]:
-            """Attend over a single chunk (L <= chunk_size) with optional cache."""
+            position_ids_blk: Optional[Tensor] = None,
+        ) -> Tuple[Tensor, Optional[AttentionCache], Tensor]:
+            """Attend over a single chunk (L <= chunk_size) with optional cache.
+
+            Args:
+                start_pos: Per-batch starting positions, shape (B,).
+            """
             if cache_limit is None:
                 keep_limit: Optional[int] = None
             else:
@@ -1038,8 +1080,15 @@ class ChunkedSelfAttention(nn.Module):
                     else None,
                 )
             B_, L_, H_, Dh_ = q_blk.shape
+            # Build position_ids for RoPE from per-batch start positions
+            if position_ids_blk is None:
+                # start_pos is (B,), build (B, L_) position indices
+                offsets = torch.arange(L_, device=device, dtype=torch.long)
+                position_ids_blk = start_pos.unsqueeze(1) + offsets.unsqueeze(0)
             # Rotate only the new block, then concatenate with already-rotated cache.
-            q_blk, k_blk = self.rope(q_blk, k_blk, start_index=start_pos)
+            q_blk, k_blk = self.rope(
+                q_blk, k_blk, start_index=0, position_ids=position_ids_blk
+            )
             if cache_blk is not None:
                 k_cat = torch.cat([cache_blk.k, k_blk], dim=1)
                 v_cat = torch.cat([cache_blk.v, v_blk], dim=1)
@@ -1066,17 +1115,20 @@ class ChunkedSelfAttention(nn.Module):
             # Only build explicit mask when we have prefix cache or padding mask.
             # SDPA is_causal=True handles causality correctly regardless of absolute position.
             if prefix_len_blk > 0 or mask_blk is not None:
-                key_positions = prefix_start + torch.arange(
-                    Lk_blk, device=device
-                )  # absolute positions of keys
-                query_positions = start_pos + torch.arange(L_, device=device)
-                causal = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+                # Per-batch positions: prefix_start and start_pos are (B,) tensors
+                # key_positions: (B, Lk), query_positions: (B, L)
+                key_offsets = torch.arange(Lk_blk, device=device)  # (Lk,)
+                key_positions = prefix_start.unsqueeze(1) + key_offsets.unsqueeze(0)
+                query_offsets = torch.arange(L_, device=device)  # (L,)
+                query_positions = start_pos.unsqueeze(1) + query_offsets.unsqueeze(0)
+                # causal: (B, L, Lk) - key_positions <= query_positions
+                causal = key_positions.unsqueeze(1) <= query_positions.unsqueeze(2)
                 base_mask = torch.where(
                     causal,
                     torch.zeros_like(causal, dtype=q_.dtype),
                     torch.tensor(float("-inf"), dtype=q_.dtype, device=device),
                 )
-                base_mask = base_mask.view(1, L_, Lk_blk).unsqueeze(1)  # (1,1,L,Lk)
+                base_mask = base_mask.unsqueeze(1)  # (B, 1, L, Lk)
                 # Apply padding mask when cache has mask OR current has mask
                 has_prefix_mask = cache_blk is not None and cache_blk.mask is not None
                 has_current_mask = mask_blk is not None
@@ -1216,25 +1268,38 @@ class ChunkedSelfAttention(nn.Module):
         if streaming_mode:
             outs: List[Tensor] = []
             cur_cache = cache
-            cur_pos = cache.count if cache is not None else start_index
+            # Convert start_index to per-batch tensor if needed
+            if cache is not None:
+                cur_pos = cache.count  # (B,) tensor
+            else:
+                cur_pos = torch.full((B,), start_index, dtype=torch.long, device=device)
             offset = 0
             while offset < L:
                 remaining = L - offset
                 if faithful_chunk_local:
                     # Enforce chunk-local attention by resetting KV at chunk boundaries.
+                    # Per-batch positions: pos_in_chunk is (B,) tensor
                     pos_in_chunk = cur_pos % self.chunk_size
-                    if pos_in_chunk == 0:
+                    # Check if ALL batches are at chunk boundary (simplification)
+                    # For variable-length batches, this is conservative but correct
+                    all_at_boundary = (pos_in_chunk == 0).all().item()
+                    if all_at_boundary:
                         cur_cache = None
-                    elif cur_cache is not None and cur_cache.length > pos_in_chunk:
-                        cur_cache = AttentionCache(
-                            k=cur_cache.k[:, -pos_in_chunk:],
-                            v=cur_cache.v[:, -pos_in_chunk:],
-                            count=cur_cache.count,
-                            mask=cur_cache.mask[:, -pos_in_chunk:]
-                            if cur_cache.mask is not None
-                            else None,
-                        )
-                    chunk_len = min(remaining, self.chunk_size - pos_in_chunk)
+                    elif cur_cache is not None:
+                        # Trim cache to max position within chunk across all batches
+                        max_pos_in_chunk = int(pos_in_chunk.max().item())
+                        if cur_cache.length > max_pos_in_chunk:
+                            cur_cache = AttentionCache(
+                                k=cur_cache.k[:, -max_pos_in_chunk:],
+                                v=cur_cache.v[:, -max_pos_in_chunk:],
+                                count=cur_cache.count,
+                                mask=cur_cache.mask[:, -max_pos_in_chunk:]
+                                if cur_cache.mask is not None
+                                else None,
+                            )
+                    # Use minimum position within chunk to determine chunk_len
+                    min_pos_in_chunk = int(pos_in_chunk.min().item())
+                    chunk_len = min(remaining, self.chunk_size - min_pos_in_chunk)
                 else:
                     chunk_len = (
                         min(remaining, self.chunk_size)
@@ -1243,11 +1308,14 @@ class ChunkedSelfAttention(nn.Module):
                     )
                 end = offset + chunk_len
                 mask_chunk = None if attn_mask is None else attn_mask[:, offset:end]
+                pos_ids_chunk = (
+                    None if position_ids is None else position_ids[:, offset:end]
+                )
                 q_blk = q[:, offset:end]
                 k_blk = k[:, offset:end]
                 v_blk = v[:, offset:end]
                 out_chunk, cur_cache, cur_pos = attend_single_chunk(
-                    q_blk, k_blk, v_blk, cur_pos, cur_cache, mask_chunk
+                    q_blk, k_blk, v_blk, cur_pos, cur_cache, mask_chunk, pos_ids_chunk
                 )
                 outs.append(out_chunk)
                 offset = end
@@ -1272,8 +1340,12 @@ class ChunkedSelfAttention(nn.Module):
 
         # Single-block path (non-streaming or already chunked)
         if L <= self.chunk_size:
+            # Convert start_index to per-batch tensor
+            start_pos_tensor = torch.full(
+                (B,), start_index, dtype=torch.long, device=device
+            )
             out, new_cache, new_pos = attend_single_chunk(
-                q, k, v, start_index, cache, attn_mask
+                q, k, v, start_pos_tensor, cache, attn_mask, position_ids
             )
             result_cache = new_cache if return_cache else None
             if return_position:
@@ -1290,7 +1362,9 @@ class ChunkedSelfAttention(nn.Module):
         if attn_mask is None:
             # === VECTORIZED PATH (fast) ===
             # Apply RoPE once to full sequence with absolute positions
-            q_rot, k_rot = self.rope(q, k, start_index=start_index)
+            q_rot, k_rot = self.rope(
+                q, k, start_index=start_index, position_ids=position_ids
+            )
 
             # Reshape: (B, L, H, Dh) -> (B*nc, C, H, Dh)
             q_chunks = q_rot.view(B, nc, C, H, Dh).reshape(B * nc, C, H, Dh)
@@ -1321,6 +1395,9 @@ class ChunkedSelfAttention(nn.Module):
             k_chunks = k[:, -L:].view(B, nc, C, H, Dh)
             v_chunks = v[:, -L:].view(B, nc, C, H, Dv)
             attn_mask_chunks = attn_mask.view(B, nc, C)
+            pos_ids_chunks = (
+                None if position_ids is None else position_ids.view(B, nc, C)
+            )
 
             # Pre-compute causal mask for manual path
             mask_block = self._causal_mask(C, C, device, torch.float32)
@@ -1330,7 +1407,10 @@ class ChunkedSelfAttention(nn.Module):
                 start_pos = start_index + i * C
                 q_blk = q_chunks[:, i]
                 k_blk = k_chunks[:, i]
-                q_blk, k_blk = self.rope(q_blk, k_blk, start_index=start_pos)
+                pos_ids_blk = None if pos_ids_chunks is None else pos_ids_chunks[:, i]
+                q_blk, k_blk = self.rope(
+                    q_blk, k_blk, start_index=start_pos, position_ids=pos_ids_blk
+                )
 
                 q_i = q_blk.transpose(1, 2)  # (B,H,C,Dh)
                 k_i = k_blk.transpose(1, 2)
@@ -1368,7 +1448,10 @@ class ChunkedSelfAttention(nn.Module):
             out = torch.cat(outs, dim=1).reshape(B, L, H * Dv)
         if pad_len:
             out = out[:, :orig_L, :]
-        final_pos = start_index + orig_L
+        # Convert final_pos to per-batch tensor
+        final_pos = torch.full(
+            (B,), start_index + orig_L, dtype=torch.long, device=device
+        )
         if return_position:
             return out, None, final_pos
         return out, None
@@ -1489,7 +1572,13 @@ class MegalodonAttention(nn.Module):
             )
         if cache is not None:
             attn_cache = cache.attn
-            position = cache.position
+            # Position is now Optional[Tensor]; when attn_cache exists, its count is used
+            # start_index is only needed when attn_cache is None
+            if cache.position is not None:
+                # Use first element for start_index (backward compat); cache.count handles per-batch
+                start_index_int = int(cache.position[0].item())
+            else:
+                start_index_int = 0
             if cache.norm is not None:
                 prev_count = cache.norm.count
                 prev_mean = cache.norm.mean
@@ -1499,7 +1588,7 @@ class MegalodonAttention(nn.Module):
             hx = cache.ema
         else:
             attn_cache = None
-            position = 0
+            start_index_int = 0
             prev_count = prev_mean = prev_var = None
             hx = None
 
@@ -1540,7 +1629,7 @@ class MegalodonAttention(nn.Module):
         r = F.silu(self.wr(mx))  # (B,L,E)
 
         # 6) Inner attention
-        start_index = position
+        start_index = start_index_int
         if max_cache_len == -1:
             cache_limit = self.inner.chunk_size
             cache_unbounded = False

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -1043,6 +1043,13 @@ class ChunkedSelfAttention(nn.Module):
             )
 
         cache = _clamp_attn_cache(cache, cache_limit)
+        if attn_mask is not None and L > 0:
+            has_valid = attn_mask.any(dim=1)
+            if not has_valid.all():
+                raise ValueError(
+                    "Fully-masked sequences are not supported in attention. "
+                    "Ensure each batch row has at least one valid token."
+                )
         if L == 0:
             empty_out = q.new_zeros((B, 0, H * Dv))
             result_cache = cache if return_cache else None

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -40,7 +40,7 @@ import contextlib
 import math
 import warnings
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -2268,7 +2268,7 @@ class MegalodonForCausalLM(PreTrainedModel, GenerationMixin):
         input_ids: torch.LongTensor,
         past_key_values: Optional[List[Optional[LayerCache]]] = None,
         attention_mask: Optional[Tensor] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> dict:
         """Prepare model inputs for generation.
 

--- a/src/megalodon/modeling_megalodon.py
+++ b/src/megalodon/modeling_megalodon.py
@@ -586,8 +586,8 @@ class ComplexEMA(nn.Module):
         :type hx: Optional[torch.Tensor]
         :param last_valid_idx: Optional tensor of shape ``(batch,)`` indicating the index
             of the last valid (unmasked) position for each batch item. When provided,
-            the returned hidden state ``h_last`` will be the state at that position,
-            ensuring that masked positions don't affect the cached state through decay.
+            the returned hidden state ``h_last`` will be the state at that position.
+            Use ``-1`` for fully-masked rows to preserve the incoming state.
         :type last_valid_idx: Optional[torch.Tensor]
         :returns: Tuple of real outputs ``(batch, dim, length)`` and final complex state.
         :rtype: Tuple[torch.Tensor, torch.Tensor]
@@ -755,11 +755,12 @@ class ComplexEMA(nn.Module):
             x = torch.where(mask_bool.unsqueeze(1), x, x.new_zeros(()))
             # Find the actual position of the last True in each row (not count-based).
             # This handles left-padding, internal zeros, and right-padding correctly.
-            # For fully-masked sequences, clamp to 0.
+            # For fully-masked sequences, keep a -1 sentinel so the cached state
+            # is preserved (no updates).
             L = mask_bool.size(1)
             indices = torch.arange(L, device=mask_bool.device)
             masked_indices = torch.where(mask_bool, indices, -1)
-            last_valid_idx = masked_indices.max(dim=-1).values.clamp(min=0)
+            last_valid_idx = masked_indices.max(dim=-1).values
 
         # Omega-weighted residual skip (MEGA lineage; present in upstream).
         residual = x * self.omega.view(1, -1, 1).to(x)

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -783,3 +783,76 @@ def test_multichunk_padding_extends_position_ids(
     )
 
     assert out.shape == (B, L, H)
+
+
+@torch.no_grad()
+def test_chunk_local_mixed_positions_match_per_sample() -> None:
+    """Mixed cached positions should not cross chunk boundaries."""
+    attn = _make_attn(chunk_size=16, sdpa=True)
+    B, H = 2, 2
+    L = 10
+
+    q, k = _zeros_qk(B, L, H, 4)
+    v = _make_v_loud(B, L, H, list(range(1, L + 1)), mask=None)
+
+    cache_len = 15
+    cache_mask = torch.zeros(B, cache_len, dtype=torch.bool)
+    cache_mask[0, :] = True
+    cache_mask[1, -1] = True
+    k_cache, _ = _zeros_qk(B, cache_len, H, 4)
+    v_cache = torch.zeros(B, cache_len, H, 1)
+    v_cache[0].fill_(1000.0)
+    v_cache[1].fill_(1.0)
+    cache = AttentionCache(
+        k=k_cache,
+        v=v_cache,
+        count=torch.tensor([15, 1], dtype=torch.long),
+        mask=cache_mask,
+    )
+
+    out_batched, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=None,
+        training=False,
+        return_cache=False,
+    )
+
+    cache0 = AttentionCache(
+        k=k_cache[:1],
+        v=v_cache[:1],
+        count=torch.tensor([15], dtype=torch.long),
+        mask=cache_mask[:1],
+    )
+    cache1 = AttentionCache(
+        k=k_cache[1:2],
+        v=v_cache[1:2],
+        count=torch.tensor([1], dtype=torch.long),
+        mask=cache_mask[1:2],
+    )
+    out0, _ = attn(
+        q[:1],
+        k[:1],
+        v[:1],
+        start_index=0,
+        cache=cache0,
+        attn_mask=None,
+        training=False,
+        return_cache=False,
+    )
+    out1, _ = attn(
+        q[1:2],
+        k[1:2],
+        v[1:2],
+        start_index=0,
+        cache=cache1,
+        attn_mask=None,
+        training=False,
+        return_cache=False,
+    )
+    out_expected = torch.cat([out0, out1], dim=0)
+
+    torch.testing.assert_close(out_batched, out_expected, atol=1e-5, rtol=1e-5)

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -853,22 +853,52 @@ def test_reference_attend_uses_position_ids_for_causality() -> None:
     assert new_cache.count == ref_cache.count
 
 
-@pytest.mark.parametrize("cache_present", [False, True])
-@pytest.mark.parametrize("cache_mask_present", [False, True])
-@pytest.mark.parametrize("return_cache", [False, True])
-@pytest.mark.parametrize("mask_present", [False, True])
-@pytest.mark.parametrize("position_ids_present", [False, True])
+def _empty_sequence_cases() -> list[tuple[bool, bool, bool, bool, bool]]:
+    cases = []
+    for cache_present in [False, True]:
+        for cache_mask_present in [False, True]:
+            for return_cache in [False, True]:
+                for mask_present in [False, True]:
+                    for position_ids_present in [False, True]:
+                        if cache_mask_present and not cache_present:
+                            continue
+                        cases.append(
+                            (
+                                cache_present,
+                                cache_mask_present,
+                                return_cache,
+                                mask_present,
+                                position_ids_present,
+                            )
+                        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    "case",
+    _empty_sequence_cases(),
+    ids=(
+        lambda c: (
+            f"cache={int(c[0])}_"
+            f"cachemask={int(c[1])}_"
+            f"return={int(c[2])}_"
+            f"mask={int(c[3])}_"
+            f"pos={int(c[4])}"
+        )
+    ),
+)
 @torch.no_grad()
 def test_empty_sequence_returns_empty(
-    cache_present: bool,
-    cache_mask_present: bool,
-    return_cache: bool,
-    mask_present: bool,
-    position_ids_present: bool,
+    case: tuple[bool, bool, bool, bool, bool],
 ) -> None:
     """Empty sequences should return empty outputs without errors."""
-    if cache_mask_present and not cache_present:
-        pytest.skip("cache_mask_present requires cache_present")
+    (
+        cache_present,
+        cache_mask_present,
+        return_cache,
+        mask_present,
+        position_ids_present,
+    ) = case
 
     attn = _make_attn(chunk_size=8, sdpa=True)
     B, H = 2, 2

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -140,6 +140,7 @@ def _reference_attend(
     start_index: int,
     cache: Optional[AttentionCache],
     mask_blk: Optional[torch.Tensor],
+    position_ids: Optional[torch.Tensor] = None,
     max_cache_len: int,
 ) -> tuple[torch.Tensor, AttentionCache]:
     """Reference implementation encoding the intended semantics.
@@ -168,14 +169,17 @@ def _reference_attend(
         start_pos = torch.full((B,), start_index, dtype=torch.long, device=q.device)
         prefix_len = 0
 
-    if mask_blk is not None:
-        mask_long = mask_blk.to(torch.long)
-        pos_offsets = mask_long.cumsum(dim=1) - 1
-        pos_offsets = pos_offsets.clamp(min=0)
-        position_ids = start_pos.unsqueeze(1) + pos_offsets
+    if position_ids is None:
+        if mask_blk is not None:
+            mask_long = mask_blk.to(torch.long)
+            pos_offsets = mask_long.cumsum(dim=1) - 1
+            pos_offsets = pos_offsets.clamp(min=0)
+            position_ids = start_pos.unsqueeze(1) + pos_offsets
+        else:
+            offsets = torch.arange(Lq, device=q.device, dtype=torch.long)
+            position_ids = start_pos.unsqueeze(1) + offsets.unsqueeze(0)
     else:
-        offsets = torch.arange(Lq, device=q.device, dtype=torch.long)
-        position_ids = start_pos.unsqueeze(1) + offsets.unsqueeze(0)
+        position_ids = position_ids.to(device=q.device, dtype=torch.long)
 
     # Apply RoPE (no-op for zero q/k, but maintain parity)
     q_rot, k_rot = attn.rope(q, k, start_index=0, position_ids=position_ids)
@@ -214,6 +218,24 @@ def _reference_attend(
         full_mask = full_mask[:, -keep:]  # suffix, not prefix
 
     Lk = k_cat.size(1)
+    if cache is not None:
+        if cache.mask is None:
+            cache_offset = cache.count - cache.length
+            cache_positions = cache_offset.unsqueeze(1) + torch.arange(
+                prefix_len, device=q.device
+            ).unsqueeze(0)
+        else:
+            cache_mask_long = cache.mask.to(torch.long)
+            cache_valid = cache_mask_long.sum(dim=1)
+            cache_offset = cache.count - cache_valid
+            cache_positions = cache_mask_long.cumsum(dim=1) - 1
+            cache_positions = cache_positions.clamp(min=0)
+            cache_positions = cache_offset.unsqueeze(1) + cache_positions
+        key_positions = torch.cat([cache_positions, position_ids], dim=1)
+    else:
+        key_positions = position_ids
+    if key_positions.size(1) > Lk:
+        key_positions = key_positions[:, -Lk:]
 
     # Manual attention computation
     q_ = q_rot.transpose(1, 2)  # (B, H, Lq, Dh)
@@ -223,10 +245,15 @@ def _reference_attend(
     # Attention scores
     scores = torch.matmul(q_, k_.transpose(-2, -1))  # (B, H, Lq, Lk)
 
-    # Causal mask
-    prefix_kept = max(0, Lk - Lq)
-    causal = attn._causal_mask(Lq, Lk, q.device, scores.dtype, offset=prefix_kept)
-    scores = scores + causal
+    # Causal mask (position-based to match implementation)
+    query_positions = position_ids
+    causal = key_positions.unsqueeze(1) <= query_positions.unsqueeze(2)
+    causal_mask = torch.where(
+        causal,
+        torch.zeros_like(causal, dtype=scores.dtype),
+        scores.new_tensor(float("-inf")),
+    )
+    scores = scores + causal_mask.unsqueeze(1)
 
     # Key validity mask
     # full_mask: (B, Lk) -> (B, 1, 1, Lk)
@@ -783,6 +810,161 @@ def test_multichunk_padding_extends_position_ids(
     )
 
     assert out.shape == (B, L, H)
+
+
+@torch.no_grad()
+def test_reference_attend_uses_position_ids_for_causality() -> None:
+    """Reference should match position-based causal masking when provided."""
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+    L = 4
+
+    q, k = _zeros_qk(B, L, H, 4)
+    v = _make_v_loud(B, L, H, [1.0, 2.0, 3.0, 4.0], mask=None)
+    mask_blk = torch.ones(B, L, dtype=torch.bool)
+    position_ids = torch.tensor([[0, 2, 2, 5]], dtype=torch.long)
+
+    out, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+        position_ids=position_ids,
+    )
+
+    ref_out, ref_cache = _reference_attend(
+        attn,
+        q=q,
+        k=k,
+        v=v,
+        start_index=0,
+        cache=None,
+        mask_blk=mask_blk,
+        position_ids=position_ids,
+        max_cache_len=8,
+    )
+
+    torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+    assert new_cache.count == ref_cache.count
+
+
+@pytest.mark.parametrize("cache_present", [False, True])
+@pytest.mark.parametrize("cache_mask_present", [False, True])
+@pytest.mark.parametrize("return_cache", [False, True])
+@pytest.mark.parametrize("mask_present", [False, True])
+@pytest.mark.parametrize("position_ids_present", [False, True])
+@torch.no_grad()
+def test_empty_sequence_returns_empty(
+    cache_present: bool,
+    cache_mask_present: bool,
+    return_cache: bool,
+    mask_present: bool,
+    position_ids_present: bool,
+) -> None:
+    """Empty sequences should return empty outputs without errors."""
+    if cache_mask_present and not cache_present:
+        pytest.skip("cache_mask_present requires cache_present")
+
+    attn = _make_attn(chunk_size=8, sdpa=True)
+    B, H = 2, 2
+    L = 0
+
+    q, k = _zeros_qk(B, L, H, 4)
+    v = torch.zeros(B, L, H, 1)
+    attn_mask = torch.ones(B, L, dtype=torch.bool) if mask_present else None
+    position_ids = torch.zeros(B, L, dtype=torch.long) if position_ids_present else None
+
+    cache = None
+    if cache_present:
+        cache_len = 3
+        k_cache, _ = _zeros_qk(B, cache_len, H, 4)
+        v_cache = torch.zeros(B, cache_len, H, 1)
+        cache_mask = None
+        if cache_mask_present:
+            cache_mask = torch.tensor(
+                [[True, True, False], [True, False, False]], dtype=torch.bool
+            )
+        cache = AttentionCache(
+            k=k_cache,
+            v=v_cache,
+            count=torch.tensor([3, 1], dtype=torch.long),
+            mask=cache_mask,
+        )
+
+    out, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=5,
+        cache=cache,
+        attn_mask=attn_mask,
+        training=False,
+        max_cache_len=8,
+        return_cache=return_cache,
+        position_ids=position_ids,
+    )
+
+    assert out.shape == (B, 0, H)
+    if return_cache and cache_present:
+        assert new_cache is not None
+        assert new_cache.length == cache.length
+        torch.testing.assert_close(new_cache.count, cache.count)
+        if cache.mask is None:
+            assert new_cache.mask is None
+        else:
+            torch.testing.assert_close(
+                new_cache.mask.to(torch.long), cache.mask.to(torch.long)
+            )
+    else:
+        assert new_cache is None
+
+
+@pytest.mark.parametrize("cache_present", [False, True])
+@torch.no_grad()
+def test_empty_sequence_returns_position(cache_present: bool) -> None:
+    """Empty sequences should not advance cached positions."""
+    attn = _make_attn(chunk_size=8, sdpa=True)
+    B, H = 2, 2
+    L = 0
+
+    q, k = _zeros_qk(B, L, H, 4)
+    v = torch.zeros(B, L, H, 1)
+
+    cache = None
+    expected_pos = torch.full((B,), 7, dtype=torch.long)
+    if cache_present:
+        cache_len = 3
+        k_cache, _ = _zeros_qk(B, cache_len, H, 4)
+        v_cache = torch.zeros(B, cache_len, H, 1)
+        cache = AttentionCache(
+            k=k_cache,
+            v=v_cache,
+            count=torch.tensor([3, 1], dtype=torch.long),
+            mask=None,
+        )
+        expected_pos = cache.count
+
+    out, new_cache, pos = attn(
+        q,
+        k,
+        v,
+        start_index=7,
+        cache=cache,
+        attn_mask=None,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+        return_position=True,
+    )
+
+    assert out.shape == (B, 0, H)
+    assert (new_cache is None) == (not cache_present)
+    torch.testing.assert_close(pos, expected_pos)
 
 
 @torch.no_grad()

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -997,6 +997,81 @@ def test_empty_sequence_returns_position(cache_present: bool) -> None:
     torch.testing.assert_close(pos, expected_pos)
 
 
+def _fully_masked_cases() -> list[tuple[bool, bool, bool, bool, int]]:
+    cases = []
+    for cache_present in [False, True]:
+        for cache_mask_present in [False, True]:
+            if cache_mask_present and not cache_present:
+                continue
+            for return_cache in [False, True]:
+                for sdpa in [False, True]:
+                    for length in [4, 10]:
+                        cases.append(
+                            (
+                                cache_present,
+                                cache_mask_present,
+                                return_cache,
+                                sdpa,
+                                length,
+                            )
+                        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    "case",
+    _fully_masked_cases(),
+    ids=lambda c: (
+        f"cache={int(c[0])}_"
+        f"cachemask={int(c[1])}_"
+        f"return={int(c[2])}_"
+        f"sdpa={int(c[3])}_"
+        f"L={c[4]}"
+    ),
+)
+@torch.no_grad()
+def test_fully_masked_rows_raise(case: tuple[bool, bool, bool, bool, int]) -> None:
+    """Fully-masked rows should raise to avoid NaNs."""
+    cache_present, cache_mask_present, return_cache, sdpa, length = case
+    attn = _make_attn(chunk_size=8, sdpa=sdpa)
+    B, H = 2, 2
+
+    q, k = _zeros_qk(B, length, H, 4)
+    v = _make_v_loud(B, length, H, list(range(1, length + 1)), mask=None)
+    attn_mask = torch.ones(B, length, dtype=torch.bool)
+    attn_mask[0].fill_(False)
+
+    cache = None
+    if cache_present:
+        cache_len = 3
+        k_cache, _ = _zeros_qk(B, cache_len, H, 4)
+        v_cache = torch.zeros(B, cache_len, H, 1)
+        cache_mask = None
+        if cache_mask_present:
+            cache_mask = torch.tensor(
+                [[True, True, False], [True, False, False]], dtype=torch.bool
+            )
+        cache = AttentionCache(
+            k=k_cache,
+            v=v_cache,
+            count=torch.tensor([3, 1], dtype=torch.long),
+            mask=cache_mask,
+        )
+
+    with pytest.raises(ValueError, match=r"Fully-masked sequences"):
+        attn(
+            q,
+            k,
+            v,
+            start_index=0,
+            cache=cache,
+            attn_mask=attn_mask,
+            training=False,
+            max_cache_len=8,
+            return_cache=return_cache,
+        )
+
+
 @torch.no_grad()
 def test_chunk_local_mixed_positions_match_per_sample() -> None:
     """Mixed cached positions should not cross chunk boundaries."""

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -32,7 +32,6 @@ pytest.importorskip("transformers")
 from megalodon import MegalodonConfig
 from megalodon.modeling_megalodon import AttentionCache, ChunkedSelfAttention
 
-
 # =============================================================================
 # Test Fixtures and Helpers
 # =============================================================================
@@ -540,7 +539,9 @@ def test_cache_mask_extended_when_current_mask_none() -> None:
     )
 
     assert new_cache.mask is not None, "Cache mask should exist (inherited from prefix)"
-    assert new_cache.mask.shape == (B, 6), f"Expected shape (1, 6), got {new_cache.mask.shape}"
+    assert new_cache.mask.shape == (B, 6), (
+        f"Expected shape (1, 6), got {new_cache.mask.shape}"
+    )
 
     # Expected: [1, 0] from cache + [1, 1, 1, 1] for new tokens
     expected = torch.tensor([[True, False, True, True, True, True]])
@@ -581,8 +582,12 @@ def test_prefix_ones_when_cache_mask_none_current_present() -> None:
         return_cache=True,
     )
 
-    assert new_cache.mask is not None, "Cache mask should exist (current mask was provided)"
-    assert new_cache.mask.shape == (B, 6), f"Expected shape (1, 6), got {new_cache.mask.shape}"
+    assert new_cache.mask is not None, (
+        "Cache mask should exist (current mask was provided)"
+    )
+    assert new_cache.mask.shape == (B, 6), (
+        f"Expected shape (1, 6), got {new_cache.mask.shape}"
+    )
 
     # Expected: [1, 1] for prefix (defaulted) + [1, 0, 1, 0] from current
     expected = torch.tensor([[True, True, True, False, True, False]])
@@ -673,7 +678,10 @@ def test_sdpa_and_manual_paths_match() -> None:
     k_cache, _ = _zeros_qk(B, 2, H, 4)
     v_cache = _make_v_loud(B, 2, H, [5.0, 500.0], mask=None)  # loud invalid
     cache = AttentionCache(
-        k=k_cache, v=v_cache, count=torch.full((B,), 2, dtype=torch.long), mask=cache_mask
+        k=k_cache,
+        v=v_cache,
+        count=torch.full((B,), 2, dtype=torch.long),
+        mask=cache_mask,
     )
 
     q, k = _zeros_qk(B, 4, H, 4)

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -750,3 +750,36 @@ def test_cache_kv_mask_length_invariant() -> None:
                 f"Step {step}: mask length {cache.mask.shape[1]} != "
                 f"KV length {cache.k.shape[1]}"
             )
+
+
+@pytest.mark.parametrize("explicit_position_ids", [False, True])
+@torch.no_grad()
+def test_multichunk_padding_extends_position_ids(
+    explicit_position_ids: bool,
+) -> None:
+    """Padding to chunk_size must keep position_ids aligned with padded length."""
+    attn = _make_attn(chunk_size=8, sdpa=True)
+    B, H = 2, 2
+    L = 10  # not divisible by chunk_size (8) -> triggers padding
+
+    q, k = _zeros_qk(B, L, H, 4)
+    v = _make_v_loud(B, L, H, list(range(1, L + 1)), mask=None)
+    attn_mask = torch.ones(B, L, dtype=torch.bool)
+    attn_mask[0, -1] = False
+
+    position_ids = None
+    if explicit_position_ids:
+        position_ids = torch.arange(L, device=q.device).unsqueeze(0).expand(B, -1)
+
+    out, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=attn_mask,
+        training=False,
+        position_ids=position_ids,
+    )
+
+    assert out.shape == (B, L, H)

--- a/tests/test_chunked_attention_exhaustive.py
+++ b/tests/test_chunked_attention_exhaustive.py
@@ -1,0 +1,744 @@
+# coding=utf-8
+"""Exhaustive test suite for ChunkedSelfAttention masking and caching.
+
+This file exists because multiple non-trivial bugs have appeared in
+`ChunkedSelfAttention.attend_single_chunk`. The root cause is combinatorial:
+correctness depends on the interaction of:
+
+    - cache_blk present vs absent
+    - mask_blk present vs absent
+    - cache_blk.mask present vs absent
+    - trimming (sliding window) active vs inactive
+    - SDPA vs manual attention path
+
+This suite:
+    1. Enumerates all valid combinations in a parametrized matrix test
+    2. Provides named regression tests for each known bug class
+    3. Uses loud test values so masking failures are obvious (not epsilon diffs)
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("transformers")
+
+from megalodon import MegalodonConfig
+from megalodon.modeling_megalodon import AttentionCache, ChunkedSelfAttention
+
+
+# =============================================================================
+# Test Fixtures and Helpers
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class _Case:
+    """A single test case configuration."""
+
+    cache_present: bool
+    mask_present: bool
+    cache_mask_present: bool
+    trim_active: bool
+    sdpa: bool
+
+    @property
+    def id(self) -> str:
+        return (
+            f"cache={int(self.cache_present)}_"
+            f"mask={int(self.mask_present)}_"
+            f"cachemask={int(self.cache_mask_present)}_"
+            f"trim={int(self.trim_active)}_"
+            f"sdpa={int(self.sdpa)}"
+        )
+
+    @property
+    def is_valid(self) -> bool:
+        """Some combinations are invalid and should be skipped or should raise."""
+        # cache_mask without cache is meaningless (skip)
+        if self.cache_mask_present and not self.cache_present:
+            return False
+        return True
+
+    @property
+    def should_raise(self) -> bool:
+        """Trim without cache requires max_cache_len < chunk_size, which must raise."""
+        return self.trim_active and not self.cache_present
+
+
+def _make_attn(*, chunk_size: int = 4, sdpa: bool = True) -> ChunkedSelfAttention:
+    """Create a small attention module for testing."""
+    attn = ChunkedSelfAttention(
+        num_heads=2,
+        head_dim=4,  # must be even for RoPE
+        value_head_dim=1,  # 1D values make expected outputs easy to compute
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    )
+    attn._sdpa_available = sdpa
+    return attn.eval()
+
+
+def _zeros_qk(
+    batch: int, length: int, heads: int, head_dim: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Create zero Q/K tensors. With q=k=0, attention is uniform over allowed keys."""
+    shape = (batch, length, heads, head_dim)
+    return torch.zeros(shape), torch.zeros(shape)
+
+
+def _make_v_loud(
+    batch: int,
+    length: int,
+    heads: int,
+    base_values: list[float],
+    mask: Optional[torch.Tensor] = None,
+    loud_value: float = 1000.0,
+) -> torch.Tensor:
+    """Create V tensor where masked positions have loud (large) values.
+
+    This makes masking bugs obvious: if a masked key leaks through,
+    the output will be off by hundreds, not by floating-point epsilon.
+    """
+    assert len(base_values) == length
+    # Shape: (1, L, 1, 1) -> broadcast to (B, L, H, 1)
+    v = torch.tensor(base_values, dtype=torch.float32).view(1, length, 1, 1)
+    v = v.expand(batch, length, heads, 1).clone()
+
+    if mask is not None:
+        # mask: (B, L) with True=valid, False=masked
+        # Add loud_value to masked positions
+        invalid = (~mask).float().view(batch, length, 1, 1)
+        v = v + invalid * loud_value
+
+    return v
+
+
+def _make_mask(batch: int, pattern: list[int]) -> torch.Tensor:
+    """Create boolean mask from 0/1 pattern. 1=valid, 0=masked."""
+    m = torch.tensor(pattern, dtype=torch.bool).view(1, -1)
+    return m.expand(batch, -1).clone()
+
+
+# =============================================================================
+# Reference Implementation (Intended Semantics)
+# =============================================================================
+
+
+def _reference_attend(
+    attn: ChunkedSelfAttention,
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    start_index: int,
+    cache: Optional[AttentionCache],
+    mask_blk: Optional[torch.Tensor],
+    max_cache_len: int,
+) -> tuple[torch.Tensor, AttentionCache]:
+    """Reference implementation encoding the intended semantics.
+
+    Key semantic invariants:
+    1. cache.mask is ALWAYS respected when present, even if mask_blk is None
+    2. Missing masks default to all-ones (all valid)
+    3. Trimming uses suffix alignment: kept = full[-keep:], not full[:keep]
+    4. Returned cache.mask matches returned K/V length
+    """
+    B, Lq, H, Dh = q.shape
+    Dv = v.size(-1)
+    chunk_size = attn.chunk_size
+
+    # Validation
+    if max_cache_len < chunk_size:
+        raise ValueError(
+            f"max_cache_len ({max_cache_len}) must be >= chunk_size ({chunk_size})"
+        )
+
+    # Determine effective start position
+    if cache is not None:
+        start_pos = cache.count
+        prefix_len = cache.length
+    else:
+        start_pos = torch.full((B,), start_index, dtype=torch.long, device=q.device)
+        prefix_len = 0
+
+    if mask_blk is not None:
+        mask_long = mask_blk.to(torch.long)
+        pos_offsets = mask_long.cumsum(dim=1) - 1
+        pos_offsets = pos_offsets.clamp(min=0)
+        position_ids = start_pos.unsqueeze(1) + pos_offsets
+    else:
+        offsets = torch.arange(Lq, device=q.device, dtype=torch.long)
+        position_ids = start_pos.unsqueeze(1) + offsets.unsqueeze(0)
+
+    # Apply RoPE (no-op for zero q/k, but maintain parity)
+    q_rot, k_rot = attn.rope(q, k, start_index=0, position_ids=position_ids)
+
+    # Concatenate with cache
+    if cache is not None:
+        k_cat = torch.cat([cache.k, k_rot], dim=1)
+        v_cat = torch.cat([cache.v, v], dim=1)
+    else:
+        k_cat = k_rot
+        v_cat = v
+
+    # Build full mask BEFORE trimming
+    # Invariant: missing segments default to all-ones
+    if cache is not None:
+        if cache.mask is not None:
+            prefix_mask = cache.mask
+        else:
+            prefix_mask = torch.ones(B, prefix_len, dtype=torch.bool, device=q.device)
+    else:
+        prefix_mask = torch.ones(B, 0, dtype=torch.bool, device=q.device)
+
+    if mask_blk is not None:
+        cur_mask = mask_blk
+    else:
+        cur_mask = torch.ones(B, Lq, dtype=torch.bool, device=q.device)
+
+    full_mask = torch.cat([prefix_mask, cur_mask], dim=1)
+
+    # Apply trimming (suffix alignment)
+    total_len = k_cat.size(1)
+    keep = min(max_cache_len, total_len)
+    if keep < total_len:
+        k_cat = k_cat[:, -keep:]
+        v_cat = v_cat[:, -keep:]
+        full_mask = full_mask[:, -keep:]  # suffix, not prefix
+
+    Lk = k_cat.size(1)
+
+    # Manual attention computation
+    q_ = q_rot.transpose(1, 2)  # (B, H, Lq, Dh)
+    k_ = k_cat.transpose(1, 2)  # (B, H, Lk, Dh)
+    v_ = v_cat.transpose(1, 2)  # (B, H, Lk, Dv)
+
+    # Attention scores
+    scores = torch.matmul(q_, k_.transpose(-2, -1))  # (B, H, Lq, Lk)
+
+    # Causal mask
+    prefix_kept = max(0, Lk - Lq)
+    causal = attn._causal_mask(Lq, Lk, q.device, scores.dtype, offset=prefix_kept)
+    scores = scores + causal
+
+    # Key validity mask
+    # full_mask: (B, Lk) -> (B, 1, 1, Lk)
+    key_mask = full_mask.float().view(B, 1, 1, Lk)
+    scores = scores + (key_mask - 1.0) * 1e9  # -inf for invalid keys
+
+    # Softmax and output
+    weights = torch.softmax(scores, dim=-1)
+    out = torch.matmul(weights, v_)  # (B, H, Lq, Dv)
+    out = out.transpose(1, 2).reshape(B, Lq, H * Dv)
+
+    # Build return cache
+    if mask_blk is not None:
+        valid_counts = mask_blk.to(torch.long).sum(dim=1)
+    else:
+        valid_counts = torch.full((B,), Lq, dtype=torch.long, device=q.device)
+    new_count = start_pos + valid_counts
+
+    # Cache mask: present if ANY mask info existed
+    if cache is not None and cache.mask is not None:
+        new_mask = full_mask
+    elif mask_blk is not None:
+        new_mask = full_mask
+    else:
+        new_mask = None
+
+    new_cache = AttentionCache(k=k_cat, v=v_cat, count=new_count, mask=new_mask)
+
+    return out, new_cache
+
+
+# =============================================================================
+# Matrix Test: All Valid Combinations
+# =============================================================================
+
+
+def _generate_cases() -> list[_Case]:
+    """Generate all valid test cases."""
+    cases = []
+    for combo in itertools.product([False, True], repeat=5):
+        case = _Case(*combo)
+        if case.is_valid:
+            cases.append(case)
+    return cases
+
+
+@pytest.mark.parametrize("case", _generate_cases(), ids=lambda c: c.id)
+@torch.no_grad()
+def test_attend_single_chunk_matrix(case: _Case) -> None:
+    """Exhaustive matrix test for all conditional combinations."""
+
+    torch.manual_seed(42)
+
+    B = 2
+    H = 2
+    Dh = 4
+    Dv = 1
+    chunk_size = 4
+    Lq = chunk_size  # current chunk is always full size
+
+    attn = _make_attn(chunk_size=chunk_size, sdpa=case.sdpa)
+
+    # Configure cache
+    if case.cache_present:
+        cache_len = chunk_size if case.trim_active else 2
+        cache_values = [10.0, 20.0, 30.0, 40.0][:cache_len]
+
+        if case.cache_mask_present:
+            # Place zeros in positions that will be dropped if trimming
+            # This catches slice-direction bugs
+            if case.trim_active:
+                cache_mask = _make_mask(B, [0, 0, 1, 1])  # first two invalid
+            else:
+                cache_mask = _make_mask(B, [1, 0])  # second invalid
+        else:
+            cache_mask = None
+
+        k_cache, _ = _zeros_qk(B, cache_len, H, Dh)
+        v_cache = _make_v_loud(B, cache_len, H, cache_values, cache_mask)
+        cache = AttentionCache(
+            k=k_cache,
+            v=v_cache,
+            count=torch.full((B,), cache_len, dtype=torch.long),
+            mask=cache_mask,
+        )
+    else:
+        cache = None
+        cache_len = 0
+        cache_mask = None
+
+    # Configure current chunk mask
+    if case.mask_present:
+        # Ensure at least one valid position to avoid all-masked rows
+        mask_blk = _make_mask(B, [1, 0, 1, 0])
+    else:
+        mask_blk = None
+
+    # Configure max_cache_len
+    if case.trim_active and not case.cache_present:
+        # This configuration should raise
+        max_cache_len = chunk_size - 1
+    else:
+        # Allow some trimming when cache is present
+        max_cache_len = chunk_size + 2  # keep 6
+
+    # Create inputs
+    q, k = _zeros_qk(B, Lq, H, Dh)
+    new_values = [1.0, 2.0, 3.0, 4.0]
+    v = _make_v_loud(B, Lq, H, new_values, mask_blk)
+
+    # Handle should-raise cases
+    if case.should_raise:
+        with pytest.raises(ValueError, match=r"max_cache_len.*chunk_size"):
+            attn(
+                q,
+                k,
+                v,
+                start_index=0,
+                cache=cache,
+                attn_mask=mask_blk,
+                training=False,
+                max_cache_len=max_cache_len,
+                return_cache=True,
+            )
+        return
+
+    # Run actual implementation
+    out, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+    )
+
+    # Run reference
+    ref_out, ref_cache = _reference_attend(
+        attn,
+        q=q,
+        k=k,
+        v=v,
+        start_index=0,
+        cache=cache,
+        mask_blk=mask_blk,
+        max_cache_len=max_cache_len,
+    )
+
+    # Compare outputs
+    torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    # Compare cache metadata
+    assert torch.equal(new_cache.count, ref_cache.count)
+    assert new_cache.length == ref_cache.length
+
+    # Compare cache mask
+    if ref_cache.mask is None:
+        assert new_cache.mask is None, "Expected no cache mask, got one"
+    else:
+        assert new_cache.mask is not None, "Expected cache mask, got None"
+        torch.testing.assert_close(
+            new_cache.mask.to(torch.long),
+            ref_cache.mask.to(torch.long),
+        )
+
+
+# =============================================================================
+# Named Regression Tests: One Per Bug Class
+# =============================================================================
+
+
+@torch.no_grad()
+def test_mask_slice_direction_under_trimming() -> None:
+    """Issue 1: mask must use suffix slice [-keep:], not prefix [:keep].
+
+    When trimming drops old keys, the kept mask must align with the kept K/V.
+    The classic bug: K/V are sliced as [-keep:] but mask is sliced as [:keep].
+
+    This test places invalid keys in positions that will be dropped, then
+    verifies those invalid keys do not affect the output. If the slice direction
+    is wrong, the dropped invalid keys will actually be kept, and their
+    loud values will corrupt the output.
+    """
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    # Cache: 4 tokens, first 2 are invalid (will be dropped by trim)
+    cache_mask = _make_mask(B, [0, 0, 1, 1])  # positions 0,1 invalid
+    cache_values = [1000.0, 1000.0, 30.0, 40.0]  # loud values for invalid
+    k_cache, _ = _zeros_qk(B, 4, H, 4)
+    v_cache = _make_v_loud(B, 4, H, cache_values, mask=None)  # values already set
+    cache = AttentionCache(
+        k=k_cache, v=v_cache, count=torch.tensor([4], dtype=torch.long), mask=cache_mask
+    )
+
+    # Current chunk: all valid
+    mask_blk = _make_mask(B, [1, 1, 1, 1])
+    new_values = [1.0, 2.0, 3.0, 4.0]
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, new_values, mask=None)
+
+    # max_cache_len=6 means we drop 2 tokens from 8 total
+    # Correct: drop positions 0,1 (the invalid ones)
+    # Bug: drop positions 6,7 (valid new tokens)
+    out, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=6,
+        return_cache=True,
+    )
+
+    # First query can attend to: kept cache [30, 40] + new [1] = positions 0,1,2
+    # With q=k=0, attention is uniform: mean([30, 40, 1]) = 71/3 ~= 23.67
+    # If slice is wrong, we would see 1000s in the output
+    expected = 71.0 / 3.0
+    actual = out[0, 0, 0].item()
+
+    assert abs(actual - expected) < 1.0, (
+        f"Slice direction bug: expected ~{expected:.2f}, got {actual:.2f}. "
+        "If actual >> expected, the mask slice used prefix instead of suffix."
+    )
+
+
+@torch.no_grad()
+def test_cache_mask_applied_when_current_mask_none() -> None:
+    """Issue 3B: cache mask must be respected even when current mask is None.
+
+    The bug: prefix mask is only applied inside `if mask_blk is not None`,
+    so passing mask_blk=None makes cached padding keys valid again.
+    """
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    # Cache: position 1 is invalid with a loud value
+    cache_mask = _make_mask(B, [1, 0])  # position 1 invalid
+    cache_values = [1.0, 1000.0]  # loud value for invalid
+    k_cache, _ = _zeros_qk(B, 2, H, 4)
+    v_cache = _make_v_loud(B, 2, H, cache_values, mask=None)
+    cache = AttentionCache(
+        k=k_cache, v=v_cache, count=torch.tensor([2], dtype=torch.long), mask=cache_mask
+    )
+
+    # Current chunk: no mask (this is the trigger)
+    new_values = [10.0, 20.0, 30.0, 40.0]
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, new_values, mask=None)
+
+    out, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=None,  # no current mask
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    # First query can attend to: cache[0]=1 (valid), cache[1]=1000 (invalid), new[0]=10
+    # Correct: mean([1, 10]) = 5.5
+    # Bug: mean([1, 1000, 10]) = 337
+    expected = 5.5
+    actual = out[0, 0, 0].item()
+
+    assert abs(actual - expected) < 1.0, (
+        f"Cache mask ignored: expected ~{expected:.2f}, got {actual:.2f}. "
+        "The cached padding mask was not applied because current mask was None."
+    )
+
+
+@torch.no_grad()
+def test_cache_mask_extended_when_current_mask_none() -> None:
+    """Issue 3B: returned cache.mask must include new tokens even if current mask is None.
+
+    When cache has a mask but current mask is None, the returned cache.mask
+    must be extended with ones for the new tokens (they are all valid).
+    """
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    cache_mask = _make_mask(B, [1, 0])
+    k_cache, _ = _zeros_qk(B, 2, H, 4)
+    v_cache = _make_v_loud(B, 2, H, [1.0, 2.0], mask=None)
+    cache = AttentionCache(
+        k=k_cache, v=v_cache, count=torch.tensor([2], dtype=torch.long), mask=cache_mask
+    )
+
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, [10.0, 20.0, 30.0, 40.0], mask=None)
+
+    _, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=None,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    assert new_cache.mask is not None, "Cache mask should exist (inherited from prefix)"
+    assert new_cache.mask.shape == (B, 6), f"Expected shape (1, 6), got {new_cache.mask.shape}"
+
+    # Expected: [1, 0] from cache + [1, 1, 1, 1] for new tokens
+    expected = torch.tensor([[True, False, True, True, True, True]])
+    torch.testing.assert_close(new_cache.mask, expected)
+
+
+@torch.no_grad()
+def test_prefix_ones_when_cache_mask_none_current_present() -> None:
+    """Issue 3A: when cache.mask is None but current mask exists, prefix defaults to all-ones.
+
+    The returned cache.mask must include the prefix as all-valid (ones),
+    not be truncated to just the current mask.
+    """
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    # Cache without mask
+    k_cache, _ = _zeros_qk(B, 2, H, 4)
+    v_cache = _make_v_loud(B, 2, H, [1.0, 2.0], mask=None)
+    cache = AttentionCache(
+        k=k_cache, v=v_cache, count=torch.tensor([2], dtype=torch.long), mask=None
+    )
+
+    # Current chunk with mask
+    mask_blk = _make_mask(B, [1, 0, 1, 0])
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, [10.0, 20.0, 30.0, 40.0], mask=None)
+
+    _, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    assert new_cache.mask is not None, "Cache mask should exist (current mask was provided)"
+    assert new_cache.mask.shape == (B, 6), f"Expected shape (1, 6), got {new_cache.mask.shape}"
+
+    # Expected: [1, 1] for prefix (defaulted) + [1, 0, 1, 0] from current
+    expected = torch.tensor([[True, True, True, False, True, False]])
+    torch.testing.assert_close(new_cache.mask, expected)
+
+
+@torch.no_grad()
+def test_max_cache_len_lt_chunk_size_rejected_runtime() -> None:
+    """Issue 2: max_cache_len < chunk_size must raise at runtime.
+
+    Allowing this silently breaks causal invariants: queries in the current
+    chunk may not be able to attend to earlier tokens in the same chunk.
+    """
+    attn = _make_attn(chunk_size=8, sdpa=True)
+    q, k = _zeros_qk(1, 4, 2, 4)
+    v = _make_v_loud(1, 4, 2, [1.0, 2.0, 3.0, 4.0], mask=None)
+
+    with pytest.raises(ValueError, match=r"max_cache_len.*chunk_size"):
+        attn(
+            q,
+            k,
+            v,
+            start_index=0,
+            cache=None,
+            attn_mask=None,
+            training=False,
+            max_cache_len=4,  # < chunk_size=8
+            return_cache=True,
+        )
+
+
+def test_max_cache_len_lt_chunk_size_rejected_config() -> None:
+    """Issue 2: MegalodonConfig should reject max_cache_len < chunk_size.
+
+    Catching this at config time is better than at runtime.
+    """
+    with pytest.raises(ValueError):
+        MegalodonConfig(chunk_size=8, max_cache_len=4)
+
+
+# =============================================================================
+# Edge Case Tests
+# =============================================================================
+
+
+@torch.no_grad()
+def test_no_mask_no_cache_baseline() -> None:
+    """Baseline: no mask, no cache should work and produce causal attention."""
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, [1.0, 2.0, 3.0, 4.0], mask=None)
+
+    out, new_cache = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=None,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    # With q=k=0, each query attends uniformly to all causal keys
+    # Query 0: mean([1]) = 1
+    # Query 1: mean([1, 2]) = 1.5
+    # Query 2: mean([1, 2, 3]) = 2
+    # Query 3: mean([1, 2, 3, 4]) = 2.5
+    expected = torch.tensor([[[1.0], [1.5], [2.0], [2.5]]])
+    expected = expected.expand(B, 4, H)
+
+    torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+    assert new_cache.mask is None, "No mask info -> cache.mask should be None"
+
+
+@torch.no_grad()
+def test_sdpa_and_manual_paths_match() -> None:
+    """SDPA and manual attention paths should produce identical results."""
+    B, H = 2, 2
+
+    # Create a non-trivial scenario: cache with mask + current with mask
+    cache_mask = _make_mask(B, [1, 0])
+    mask_blk = _make_mask(B, [1, 1, 0, 1])
+
+    k_cache, _ = _zeros_qk(B, 2, H, 4)
+    v_cache = _make_v_loud(B, 2, H, [5.0, 500.0], mask=None)  # loud invalid
+    cache = AttentionCache(
+        k=k_cache, v=v_cache, count=torch.full((B,), 2, dtype=torch.long), mask=cache_mask
+    )
+
+    q, k = _zeros_qk(B, 4, H, 4)
+    v = _make_v_loud(B, 4, H, [1.0, 2.0, 300.0, 4.0], mask=None)  # loud invalid
+
+    attn_sdpa = _make_attn(chunk_size=4, sdpa=True)
+    attn_manual = _make_attn(chunk_size=4, sdpa=False)
+
+    out_sdpa, cache_sdpa = attn_sdpa(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    out_manual, cache_manual = attn_manual(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=cache,
+        attn_mask=mask_blk,
+        training=False,
+        max_cache_len=8,
+        return_cache=True,
+    )
+
+    torch.testing.assert_close(out_sdpa, out_manual, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(cache_sdpa.mask, cache_manual.mask)
+
+
+@torch.no_grad()
+def test_cache_kv_mask_length_invariant() -> None:
+    """Invariant: cache.mask.shape[1] must always equal cache.k.shape[1]."""
+    attn = _make_attn(chunk_size=4, sdpa=True)
+    B, H = 1, 2
+
+    # Run through several forward passes, checking invariant after each
+    cache = None
+    for step in range(5):
+        q, k = _zeros_qk(B, 4, H, 4)
+        v = _make_v_loud(B, 4, H, [1.0, 2.0, 3.0, 4.0], mask=None)
+
+        # Alternate: sometimes provide mask, sometimes do not
+        mask_blk = _make_mask(B, [1, 1, 0, 1]) if step % 2 == 0 else None
+
+        _, cache = attn(
+            q,
+            k,
+            v,
+            start_index=0 if cache is None else 0,
+            cache=cache,
+            attn_mask=mask_blk,
+            training=False,
+            max_cache_len=8,
+            return_cache=True,
+        )
+
+        if cache.mask is not None:
+            assert cache.mask.shape[1] == cache.k.shape[1], (
+                f"Step {step}: mask length {cache.mask.shape[1]} != "
+                f"KV length {cache.k.shape[1]}"
+            )

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -1368,13 +1368,13 @@ def test_cema_mask_batched_matches_unbatched() -> None:
         f"max diff = {(y_short - y_padded[:, :, :L_short]).abs().max()}"
     )
     # Hidden state should match (padding contributes nothing to EMA state)
+    # This is the key invariant: cached h_last must be equivalent for batched vs unbatched
     assert torch.allclose(h_short, h_padded, atol=1e-5), (
         f"CEMA hidden states differ: max diff = {(h_short - h_padded).abs().max()}"
     )
-    # Padded output positions should be zero (input was zeroed by mask)
-    assert torch.allclose(
-        y_padded[:, :, L_short:], torch.zeros_like(y_padded[:, :, L_short:]), atol=1e-6
-    ), "Padded positions should have zero output"
+    # Note: Padded output positions are NOT zero because EMA has a "decay tail" -
+    # the recurrence h[t] = q * h[t-1] + p * 0 = q * h[t-1] continues to produce
+    # non-zero output y[t] = Re(h[t] * gamma). This is expected EMA behavior.
 
 
 @torch.no_grad()

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -1384,6 +1384,23 @@ def test_cema_mask_left_padding_matches_unbatched() -> None:
 
 
 @torch.no_grad()
+def test_cema_mask_fully_padded_preserves_state() -> None:
+    """Fully masked chunks must preserve the incoming EMA state."""
+    torch.manual_seed(0)
+    D, N, L = 4, 3, 8
+    cema = ComplexEMA(D, N).eval()
+
+    hx = torch.randn(1, D, N, dtype=torch.complex64)
+    x = torch.randn(1, D, L)
+    mask = torch.zeros(1, L, dtype=torch.bool)
+
+    _, h_last = cema(x, hx=hx, compute_last_state=True, mask=mask)
+
+    assert h_last is not None
+    torch.testing.assert_close(h_last, hx)
+
+
+@torch.no_grad()
 def test_cema_fft_matches_sequential_with_mask() -> None:
     """FFT and sequential EMA paths must match when mask is applied."""
     torch.manual_seed(0)

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -866,8 +866,14 @@ def test_cache_equivalence_multi_chunk_tail() -> None:
 
 
 def test_attention_cache_respects_max_len() -> None:
-    """Attention cache should obey the caller-provided max_cache_len limit."""
+    """Attention cache should obey the caller-provided max_cache_len limit.
+
+    Note: max_cache_len must be >= chunk_size to preserve causality.
+    This test verifies trimming works when processing more tokens than max_cache_len.
+    """
     torch.manual_seed(0)
+    chunk_size = 8
+    max_cache_len = 12  # Must be >= chunk_size
     cfg = MegalodonConfig(
         model_dim=16,
         num_layers=1,
@@ -875,28 +881,43 @@ def test_attention_cache_respects_max_len() -> None:
         z_dim=16,
         value_dim=16,
         ffn_hidden_dim=32,
-        chunk_size=8,
+        chunk_size=chunk_size,
         norm_num_groups=4,
         attention_dropout=0.0,
         hidden_dropout=0.0,
         dropout=0.0,
     )
     attn = MegalodonAttention(cfg).eval()
-    B, L = 1, cfg.chunk_size
-    x = torch.randn(B, L, cfg.model_dim)
-    mask = torch.ones(B, L, dtype=torch.long)
+    B = 1
 
-    _, cache = attn(
-        x,
+    # First forward: process 8 tokens
+    x1 = torch.randn(B, chunk_size, cfg.model_dim)
+    mask1 = torch.ones(B, chunk_size, dtype=torch.long)
+    _, cache1 = attn(
+        x1,
         cache=None,
-        attn_mask=mask,
+        attn_mask=mask1,
         return_cache=True,
-        max_cache_len=5,
+        max_cache_len=max_cache_len,
     )
+    assert cache1 is not None and cache1.attn is not None
+    assert cache1.attn.k.shape[1] == chunk_size  # 8 tokens cached
+    assert cache1.attn.count == chunk_size
 
-    assert cache is not None and cache.attn is not None
-    assert cache.attn.k.shape[1] == 5
-    assert cache.attn.count == L
+    # Second forward: process 8 more tokens (total 16 > max_cache_len=12)
+    x2 = torch.randn(B, chunk_size, cfg.model_dim)
+    mask2 = torch.ones(B, chunk_size, dtype=torch.long)
+    _, cache2 = attn(
+        x2,
+        cache=cache1,
+        attn_mask=mask2,
+        return_cache=True,
+        max_cache_len=max_cache_len,
+    )
+    assert cache2 is not None and cache2.attn is not None
+    # After 16 tokens processed, cache should be trimmed to max_cache_len=12
+    assert cache2.attn.k.shape[1] == max_cache_len
+    assert cache2.attn.count == 2 * chunk_size  # Total tokens seen
 
 
 def test_attention_cache_truncation_keeps_causality() -> None:
@@ -1701,3 +1722,72 @@ def test_mask_trim_direction_matches_kv() -> None:
     # [False, False, True, True] which would be incorrect
     wrong_mask = torch.tensor([[False, False, True, True]])
     assert not torch.equal(new_cache.mask, wrong_mask), "Bug detected: mask trimmed from wrong direction"
+
+
+def test_rejects_max_cache_len_below_chunk_size() -> None:
+    """max_cache_len < chunk_size must raise ValueError to prevent causality breakage.
+
+    If max_cache_len is smaller than chunk_size, keys from the current chunk
+    would be trimmed before all queries can attend to them, breaking causal
+    attention semantics.
+    """
+    chunk_size = 16
+    B, H, Dh, Dv = 1, 2, 8, 8
+
+    attn = ChunkedSelfAttention(
+        num_heads=H,
+        head_dim=Dh,
+        value_head_dim=Dv,
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    )
+
+    # Create input that would require attention
+    q = torch.randn(B, 10, H, Dh)
+    k = torch.randn(B, 10, H, Dh)
+    v = torch.randn(B, 10, H, Dv)
+
+    # max_cache_len=8 < chunk_size=16 should fail
+    with pytest.raises(ValueError, match=r"max_cache_len.*must be >= chunk_size"):
+        attn(
+            q,
+            k,
+            v,
+            start_index=0,
+            cache=None,
+            attn_mask=None,
+            training=False,
+            max_cache_len=8,  # Less than chunk_size=16
+            return_cache=True,
+        )
+
+    # Equal to chunk_size should work
+    out, cache, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=None,
+        training=False,
+        max_cache_len=chunk_size,
+        return_cache=True,
+        return_position=True,
+    )
+    assert out.shape == (B, 10, H * Dv)
+
+    # Greater than chunk_size should work (sliding window)
+    out2, cache2, _ = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=None,
+        training=False,
+        max_cache_len=32,  # Greater than chunk_size
+        return_cache=True,
+        return_position=True,
+    )
+    assert out2.shape == (B, 10, H * Dv)

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -1633,3 +1633,71 @@ def test_attention_cache_preserves_mask() -> None:
         f"Expected updated mask {expected_updated.tolist()}, "
         f"got {updated_cache.attn.mask.tolist()}"
     )
+
+
+@torch.no_grad()
+def test_mask_trim_direction_matches_kv() -> None:
+    """Regression test: mask trimming direction must match K/V trimming (right-aligned).
+
+    When cache is trimmed via sliding window (max_cache_len), both K/V and mask
+    should keep the rightmost (most recent) tokens. Previously, the mask was
+    incorrectly trimmed from the left ([:, :Lk_blk]) instead of right ([:, -Lk_blk:]).
+    """
+    torch.manual_seed(42)
+    chunk_size = 4
+    max_cache_len = 4
+    B, H, Dh, Dv = 1, 2, 8, 8
+
+    attn = ChunkedSelfAttention(
+        num_heads=H,
+        head_dim=Dh,
+        value_head_dim=Dv,
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    ).eval()
+
+    # Build a cache with 6 tokens, first 2 are padding
+    # mask: [False, False, True, True, True, True] (positions 0,1 padded)
+    cache_k = torch.randn(B, 6, H, Dh)
+    cache_v = torch.randn(B, 6, H, Dv)
+    cache_mask = torch.tensor([[False, False, True, True, True, True]])
+    cache = AttentionCache(k=cache_k, v=cache_v, count=6, mask=cache_mask)
+
+    # Add 2 new tokens with all-valid mask
+    q = torch.randn(B, 2, H, Dh)
+    k = torch.randn(B, 2, H, Dh)
+    v = torch.randn(B, 2, H, Dv)
+    new_mask = torch.ones(B, 2, dtype=torch.bool)
+
+    out, new_cache, new_pos = attn(
+        q,
+        k,
+        v,
+        start_index=6,
+        cache=cache,
+        attn_mask=new_mask,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    # After adding 2 tokens: total 8 tokens, trimmed to last 4
+    # Original positions 0-5 (mask: F,F,T,T,T,T) + new 6-7 (mask: T,T)
+    # Combined: F,F,T,T,T,T,T,T -> keep last 4: positions 4,5,6,7 -> T,T,T,T
+    assert new_cache is not None
+    assert new_cache.mask is not None
+    assert new_cache.length == max_cache_len, f"Expected cache length {max_cache_len}, got {new_cache.length}"
+
+    # The mask should be all True because we kept positions 4-7 which were all valid
+    expected_mask = torch.ones(B, max_cache_len, dtype=torch.bool)
+    assert torch.equal(new_cache.mask, expected_mask), (
+        f"Mask mismatch: expected all-True after trimming rightmost valid tokens, "
+        f"got {new_cache.mask.tolist()}"
+    )
+
+    # Additional check: if we had kept the leftmost tokens (the bug), the mask would be
+    # [False, False, True, True] which would be incorrect
+    wrong_mask = torch.tensor([[False, False, True, True]])
+    assert not torch.equal(new_cache.mask, wrong_mask), "Bug detected: mask trimmed from wrong direction"

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -734,10 +734,12 @@ def test_complex_ema_fft_chunked_matches_full() -> None:
     )
 
 
-def test_layer_cache_rejects_invalid_type() -> None:
-    """MegalodonAttention must reject invalid cache types with TypeError."""
-    import pytest
+def test_layer_cache_handles_incompatible_types() -> None:
+    """MegalodonModel should silently fall back to fresh cache for incompatible cache types.
 
+    This is important for HF generate() compatibility where incompatible cache
+    formats (e.g., DynamicCache tuples) may be passed.
+    """
     torch.manual_seed(0)
     cfg = MegalodonConfig(
         vocab_size=256,
@@ -752,13 +754,16 @@ def test_layer_cache_rejects_invalid_type() -> None:
 
     # Valid: None cache works
     with torch.no_grad():
-        _ = model(x, use_cache=False)
+        out_none = model(x, use_cache=False)
 
-    # Invalid: tuple cache should raise TypeError
-    invalid_cache = [(None, None, None)]  # Old-style tuple cache
-    with pytest.raises(TypeError, match="Expected cache to be LayerCache"):
-        with torch.no_grad():
-            _ = model(x, past_key_values=invalid_cache)
+    # Incompatible cache format: should silently fall back to fresh cache
+    # (instead of raising TypeError, for HF generate() compatibility)
+    incompatible_cache = [(None, None, None)]  # Old-style tuple cache
+    with torch.no_grad():
+        out_incompat = model(x, past_key_values=incompatible_cache, use_cache=False)
+
+    # Both should produce valid outputs (not crash)
+    assert out_none.logits.shape == out_incompat.logits.shape
 
 
 @torch.no_grad()
@@ -2068,3 +2073,146 @@ def test_per_batch_positions_variable_length() -> None:
     assert (cache2.count == expected_count).all(), (
         f"Expected count {expected_count}, got {cache2.count}"
     )
+
+
+@torch.no_grad()
+def test_prepare_inputs_for_generation() -> None:
+    """prepare_inputs_for_generation should slice to last token when cache is provided."""
+    from megalodon import MegalodonConfig, MegalodonForCausalLM
+
+    config = MegalodonConfig(
+        model_dim=64,
+        num_heads=2,
+        hidden_dim=128,
+        num_layers=2,
+        chunk_size=8,
+    )
+    model = MegalodonForCausalLM(config).eval()
+
+    B, L = 2, 5
+    input_ids = torch.randint(0, config.vocab_size, (B, L))
+    attention_mask = torch.ones(B, L, dtype=torch.long)
+
+    # Without cache: should return full input_ids
+    inputs_no_cache = model.prepare_inputs_for_generation(
+        input_ids=input_ids, attention_mask=attention_mask
+    )
+    assert inputs_no_cache["input_ids"].shape == (B, L)
+    assert inputs_no_cache["attention_mask"].shape == (B, L)
+    assert inputs_no_cache["past_key_values"] is None
+
+    # With cache: should return only last token
+    # First, get cache from a forward pass
+    outputs = model(input_ids, attention_mask=attention_mask, use_cache=True)
+    cache = outputs.past_key_values
+
+    extended_input_ids = torch.randint(0, config.vocab_size, (B, L + 1))
+    extended_mask = torch.ones(B, L + 1, dtype=torch.long)
+
+    inputs_with_cache = model.prepare_inputs_for_generation(
+        input_ids=extended_input_ids,
+        past_key_values=cache,
+        attention_mask=extended_mask,
+    )
+    assert inputs_with_cache["input_ids"].shape == (B, 1)
+    assert inputs_with_cache["attention_mask"].shape == (B, 1)
+    assert inputs_with_cache["past_key_values"] is cache
+
+
+@torch.no_grad()
+def test_reorder_cache_beam_search() -> None:
+    """_reorder_cache should correctly reorder all cache components by beam_idx."""
+    from megalodon import MegalodonConfig, MegalodonForCausalLM
+    from megalodon.modeling_megalodon import LayerCache, NormState
+
+    config = MegalodonConfig(
+        model_dim=64,
+        num_heads=2,
+        hidden_dim=128,
+        num_layers=2,
+        chunk_size=8,
+    )
+    model = MegalodonForCausalLM(config).eval()
+
+    B, L = 3, 4
+    input_ids = torch.randint(0, config.vocab_size, (B, L))
+    attention_mask = torch.ones(B, L, dtype=torch.long)
+
+    # Get cache from a forward pass
+    outputs = model(input_ids, attention_mask=attention_mask, use_cache=True)
+    cache = outputs.past_key_values
+
+    # Reorder: keep beams [2, 0, 1] (reorder batch dimension)
+    beam_idx = torch.tensor([2, 0, 1])
+    reordered_cache = model._reorder_cache(cache, beam_idx)
+
+    # Verify reordering for each item in cache
+    for idx, (orig, reord) in enumerate(zip(cache, reordered_cache)):
+        if orig is None:
+            assert reord is None
+            continue
+
+        # Handle NormState (final norm state)
+        if isinstance(orig, NormState):
+            assert isinstance(reord, NormState)
+            assert torch.allclose(reord.count[0], orig.count[2])
+            assert torch.allclose(reord.mean[0], orig.mean[2])
+            continue
+
+        # Handle LayerCache
+        assert isinstance(orig, LayerCache)
+        assert isinstance(reord, LayerCache)
+
+        # Check attention cache
+        if orig.attn is not None:
+            assert torch.allclose(reord.attn.k[0], orig.attn.k[2])
+            assert torch.allclose(reord.attn.k[1], orig.attn.k[0])
+            assert torch.allclose(reord.attn.k[2], orig.attn.k[1])
+
+            assert torch.allclose(reord.attn.v[0], orig.attn.v[2])
+            assert torch.allclose(reord.attn.count[0], orig.attn.count[2])
+
+        # Check norm state inside LayerCache
+        if orig.norm is not None:
+            assert torch.allclose(reord.norm.count[0], orig.norm.count[2])
+            assert torch.allclose(reord.norm.mean[0], orig.norm.mean[2])
+
+        # Check EMA state
+        if orig.ema is not None:
+            assert torch.allclose(reord.ema[0], orig.ema[2])
+
+        # Check position
+        if orig.position is not None:
+            assert torch.allclose(reord.position[0], orig.position[2])
+
+
+@torch.no_grad()
+def test_generate_greedy() -> None:
+    """Basic end-to-end greedy generation should work."""
+    from megalodon import MegalodonConfig, MegalodonForCausalLM
+
+    config = MegalodonConfig(
+        model_dim=64,
+        num_heads=2,
+        hidden_dim=128,
+        num_layers=2,
+        chunk_size=8,
+        vocab_size=100,
+    )
+    model = MegalodonForCausalLM(config).eval()
+
+    B, L = 1, 4
+    input_ids = torch.randint(0, config.vocab_size, (B, L))
+
+    # Generate a few tokens with greedy decoding
+    generated = model.generate(
+        input_ids,
+        max_new_tokens=3,
+        do_sample=False,
+        use_cache=True,
+    )
+
+    # Output should have L + 3 tokens
+    assert generated.shape == (B, L + 3)
+    # First L tokens should match input
+    assert torch.equal(generated[:, :L], input_ids)

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -529,69 +529,6 @@ def test_complex_ema_fft_handles_zero_q() -> None:
     assert torch.isfinite(y).all()
 
 
-def test_sdpa_with_prefix_and_padding_matches_reference() -> None:
-    """Manual attention path should match the SDPA fallback with prefix padding."""
-    torch.manual_seed(0)
-    chunk_size = 4
-    prefix_len = 3
-    num_heads, head_dim, value_head_dim = 2, 4, 4
-    attn = ChunkedSelfAttention(
-        num_heads=num_heads,
-        head_dim=head_dim,
-        value_head_dim=value_head_dim,
-        chunk_size=chunk_size,
-        rope_base=10_000.0,
-        attention_dropout=0.0,
-    )
-
-    B = 1
-    q = torch.randn(B, chunk_size, num_heads, head_dim)
-    k = torch.randn(B, chunk_size, num_heads, head_dim)
-    v = torch.randn(B, chunk_size, num_heads, value_head_dim)
-    cache_k = torch.randn(B, prefix_len, num_heads, head_dim)
-    cache_v = torch.randn(B, prefix_len, num_heads, value_head_dim)
-    cache = AttentionCache(cache_k, cache_v, torch.tensor([prefix_len]))
-    attn_mask = torch.tensor([[1, 0, 1, 1]], dtype=torch.long)
-
-    out_sdpa, _ = attn(
-        q,
-        k,
-        v,
-        start_index=prefix_len,
-        cache=cache,
-        attn_mask=attn_mask,
-        training=False,
-        max_cache_len=prefix_len + chunk_size,
-    )
-
-    q_rot, k_rot = attn.rope(q, k, start_index=prefix_len)
-    k_full = torch.cat([cache_k, k_rot], dim=1)
-    v_full = torch.cat([cache_v, v], dim=1)
-
-    q_ = q_rot.transpose(1, 2)
-    k_ = k_full.transpose(1, 2)
-    v_ = v_full.transpose(1, 2)
-
-    scores = torch.matmul(q_, k_.transpose(-2, -1))
-    causal = attn._causal_mask(
-        chunk_size,
-        prefix_len + chunk_size,
-        q.device,
-        q.dtype,
-        offset=prefix_len,
-    )
-    scores = scores + causal
-
-    prefix_mask = attn_mask.new_ones(B, prefix_len)
-    mask_tokens = torch.cat([prefix_mask, attn_mask], dim=1)
-    invalid = mask_tokens == 0
-    scores = scores.masked_fill(invalid.view(B, 1, 1, -1), float("-inf"))
-
-    weights = torch.softmax(scores.float(), dim=-1).to(q_)
-    ref = torch.matmul(weights, v_).transpose(1, 2).reshape(B, chunk_size, -1)
-    assert torch.allclose(out_sdpa, ref, atol=1e-5, rtol=1e-5)
-
-
 def test_timestep_norm_streaming_matches_full() -> None:
     """Streaming TimestepNorm should match processing the whole sequence at once."""
     torch.manual_seed(0)
@@ -907,7 +844,7 @@ def test_attention_cache_respects_max_len() -> None:
     )
     assert cache1 is not None and cache1.attn is not None
     assert cache1.attn.k.shape[1] == chunk_size  # 8 tokens cached
-    assert cache1.attn.count == chunk_size
+    assert int(cache1.attn.count[0].item()) == chunk_size
 
     # Second forward: process 8 more tokens (total 16 > max_cache_len=12)
     x2 = torch.randn(B, chunk_size, cfg.model_dim)
@@ -922,7 +859,7 @@ def test_attention_cache_respects_max_len() -> None:
     assert cache2 is not None and cache2.attn is not None
     # After 16 tokens processed, cache should be trimmed to max_cache_len=12
     assert cache2.attn.k.shape[1] == max_cache_len
-    assert cache2.attn.count == 2 * chunk_size  # Total tokens seen
+    assert int(cache2.attn.count[0].item()) == 2 * chunk_size  # Total tokens seen
 
 
 def test_attention_cache_truncation_keeps_causality() -> None:
@@ -1640,7 +1577,7 @@ def test_attention_cache_preserves_mask() -> None:
     assert layer_cache.attn is not None
     assert layer_cache.attn.mask is not None, "AttentionCache should store mask"
 
-    # Verify mask values - first L_total-L_valid positions should be False (padded)
+    # Cache keeps the full chunk before the next-step trim is applied.
     expected_mask = torch.zeros(1, L_total, dtype=torch.bool)
     expected_mask[:, -L_valid:] = True
     assert torch.equal(layer_cache.attn.mask, expected_mask), (
@@ -1655,8 +1592,7 @@ def test_attention_cache_preserves_mask() -> None:
     # Verify updated cache mask includes the new valid token
     updated_cache = out2.past_key_values[0]
     assert updated_cache.attn.mask is not None
-    expected_updated = torch.zeros(1, L_total + 1, dtype=torch.bool)
-    expected_updated[:, -L_valid - 1 :] = True  # original valid + new token
+    expected_updated = torch.ones(1, L_valid + 1, dtype=torch.bool)
     assert torch.equal(updated_cache.attn.mask, expected_updated), (
         f"Expected updated mask {expected_updated.tolist()}, "
         f"got {updated_cache.attn.mask.tolist()}"
@@ -1664,322 +1600,6 @@ def test_attention_cache_preserves_mask() -> None:
 
 
 @torch.no_grad()
-def test_mask_trim_direction_matches_kv() -> None:
-    """Regression test: mask trimming direction must match K/V trimming (right-aligned).
-
-    When cache is trimmed via sliding window (max_cache_len), both K/V and mask
-    should keep the rightmost (most recent) tokens. Previously, the mask was
-    incorrectly trimmed from the left ([:, :Lk_blk]) instead of right ([:, -Lk_blk:]).
-    """
-    torch.manual_seed(42)
-    chunk_size = 4
-    max_cache_len = 4
-    B, H, Dh, Dv = 1, 2, 8, 8
-
-    attn = ChunkedSelfAttention(
-        num_heads=H,
-        head_dim=Dh,
-        value_head_dim=Dv,
-        chunk_size=chunk_size,
-        rope_base=10_000.0,
-        attention_dropout=0.0,
-    ).eval()
-
-    # Build a cache with 6 tokens, first 2 are padding
-    # mask: [False, False, True, True, True, True] (positions 0,1 padded)
-    cache_k = torch.randn(B, 6, H, Dh)
-    cache_v = torch.randn(B, 6, H, Dv)
-    cache_mask = torch.tensor([[False, False, True, True, True, True]])
-    cache = AttentionCache(k=cache_k, v=cache_v, count=torch.tensor([6]), mask=cache_mask)
-
-    # Add 2 new tokens with all-valid mask
-    q = torch.randn(B, 2, H, Dh)
-    k = torch.randn(B, 2, H, Dh)
-    v = torch.randn(B, 2, H, Dv)
-    new_mask = torch.ones(B, 2, dtype=torch.bool)
-
-    out, new_cache, new_pos = attn(
-        q,
-        k,
-        v,
-        start_index=6,
-        cache=cache,
-        attn_mask=new_mask,
-        training=False,
-        max_cache_len=max_cache_len,
-        return_cache=True,
-        return_position=True,
-    )
-
-    # After adding 2 tokens: total 8 tokens, trimmed to last 4
-    # Original positions 0-5 (mask: F,F,T,T,T,T) + new 6-7 (mask: T,T)
-    # Combined: F,F,T,T,T,T,T,T -> keep last 4: positions 4,5,6,7 -> T,T,T,T
-    assert new_cache is not None
-    assert new_cache.mask is not None
-    assert new_cache.length == max_cache_len, f"Expected cache length {max_cache_len}, got {new_cache.length}"
-
-    # The mask should be all True because we kept positions 4-7 which were all valid
-    expected_mask = torch.ones(B, max_cache_len, dtype=torch.bool)
-    assert torch.equal(new_cache.mask, expected_mask), (
-        f"Mask mismatch: expected all-True after trimming rightmost valid tokens, "
-        f"got {new_cache.mask.tolist()}"
-    )
-
-    # Additional check: if we had kept the leftmost tokens (the bug), the mask would be
-    # [False, False, True, True] which would be incorrect
-    wrong_mask = torch.tensor([[False, False, True, True]])
-    assert not torch.equal(new_cache.mask, wrong_mask), "Bug detected: mask trimmed from wrong direction"
-
-
-def test_rejects_max_cache_len_below_chunk_size() -> None:
-    """max_cache_len < chunk_size must raise ValueError to prevent causality breakage.
-
-    If max_cache_len is smaller than chunk_size, keys from the current chunk
-    would be trimmed before all queries can attend to them, breaking causal
-    attention semantics.
-    """
-    chunk_size = 16
-    B, H, Dh, Dv = 1, 2, 8, 8
-
-    attn = ChunkedSelfAttention(
-        num_heads=H,
-        head_dim=Dh,
-        value_head_dim=Dv,
-        chunk_size=chunk_size,
-        rope_base=10_000.0,
-        attention_dropout=0.0,
-    )
-
-    # Create input that would require attention
-    q = torch.randn(B, 10, H, Dh)
-    k = torch.randn(B, 10, H, Dh)
-    v = torch.randn(B, 10, H, Dv)
-
-    # max_cache_len=8 < chunk_size=16 should fail
-    with pytest.raises(ValueError, match=r"max_cache_len.*must be >= chunk_size"):
-        attn(
-            q,
-            k,
-            v,
-            start_index=0,
-            cache=None,
-            attn_mask=None,
-            training=False,
-            max_cache_len=8,  # Less than chunk_size=16
-            return_cache=True,
-        )
-
-    # Equal to chunk_size should work
-    out, cache, _ = attn(
-        q,
-        k,
-        v,
-        start_index=0,
-        cache=None,
-        attn_mask=None,
-        training=False,
-        max_cache_len=chunk_size,
-        return_cache=True,
-        return_position=True,
-    )
-    assert out.shape == (B, 10, H * Dv)
-
-    # Greater than chunk_size should work (sliding window)
-    out2, cache2, _ = attn(
-        q,
-        k,
-        v,
-        start_index=0,
-        cache=None,
-        attn_mask=None,
-        training=False,
-        max_cache_len=32,  # Greater than chunk_size
-        return_cache=True,
-        return_position=True,
-    )
-    assert out2.shape == (B, 10, H * Dv)
-
-
-@pytest.mark.parametrize(
-    "cache_present,cache_has_mask,current_has_mask",
-    [
-        (False, False, False),  # No cache, no mask
-        (False, False, True),  # No cache, with current mask
-        (True, False, False),  # Cache without mask, no current mask
-        (True, False, True),  # Cache without mask, with current mask
-        (True, True, False),  # Cache WITH mask, NO current mask (THE BUG)
-        (True, True, True),  # Cache with mask, with current mask
-    ],
-)
-@torch.no_grad()
-def test_attend_mask_combinations(
-    cache_present: bool, cache_has_mask: bool, current_has_mask: bool
-) -> None:
-    """Test all combinations of cache/mask presence in attend_single_chunk.
-
-    This is a regression test for the bug where cache.mask was ignored when
-    mask_blk (current mask) was None. The fix ensures prefix mask is always
-    applied when cache.mask exists.
-    """
-    torch.manual_seed(42)
-    chunk_size = 4
-    B, H, Dh, Dv = 1, 2, 8, 8
-    max_cache_len = 8
-
-    attn = ChunkedSelfAttention(
-        num_heads=H,
-        head_dim=Dh,
-        value_head_dim=Dv,
-        chunk_size=chunk_size,
-        rope_base=10_000.0,
-        attention_dropout=0.0,
-    ).eval()
-
-    # Build cache if needed
-    if cache_present:
-        cache_len = 4
-        cache_k = torch.randn(B, cache_len, H, Dh)
-        cache_v = torch.randn(B, cache_len, H, Dv)
-        if cache_has_mask:
-            # First 2 positions are padding
-            cache_mask = torch.tensor([[False, False, True, True]])
-        else:
-            cache_mask = None
-        cache = AttentionCache(
-            k=cache_k, v=cache_v, count=torch.tensor([cache_len]), mask=cache_mask
-        )
-        start_index = cache_len
-    else:
-        cache = None
-        start_index = 0
-
-    # Build current input
-    q = torch.randn(B, 2, H, Dh)
-    k = torch.randn(B, 2, H, Dh)
-    v = torch.randn(B, 2, H, Dv)
-
-    if current_has_mask:
-        current_mask = torch.ones(B, 2, dtype=torch.bool)
-    else:
-        current_mask = None
-
-    # Run attention
-    out, new_cache, new_pos = attn(
-        q,
-        k,
-        v,
-        start_index=start_index,
-        cache=cache,
-        attn_mask=current_mask,
-        training=False,
-        max_cache_len=max_cache_len,
-        return_cache=True,
-        return_position=True,
-    )
-
-    # Basic shape checks
-    assert out.shape == (B, 2, H * Dv)
-    assert new_cache is not None
-
-    # Verify mask consistency
-    if cache_has_mask or current_has_mask:
-        # When any mask is present, output cache must have mask
-        assert new_cache.mask is not None, (
-            f"Cache mask should be present when cache_has_mask={cache_has_mask} "
-            f"or current_has_mask={current_has_mask}"
-        )
-        # Mask length must match K/V length
-        assert new_cache.mask.shape[1] == new_cache.length, (
-            f"Mask length {new_cache.mask.shape[1]} != cache length {new_cache.length}"
-        )
-
-    # Special check for THE BUG case: cache.mask present, current mask None
-    if cache_has_mask and not current_has_mask:
-        # The new cache should still have mask reflecting the padding
-        assert new_cache.mask is not None
-        # The mask should include all-ones for the new tokens
-        # After concat: [F,F,T,T] + [T,T] = [F,F,T,T,T,T] (if no trimming)
-        # The rightmost positions (new tokens) should be True
-        assert new_cache.mask[0, -2:].all(), (
-            f"New tokens should be valid (True), got {new_cache.mask[0, -2:].tolist()}"
-        )
-
-
-@torch.no_grad()
-def test_cache_mask_continuity_without_current_mask() -> None:
-    """Regression test: cache.mask must be respected even when current mask is None.
-
-    This tests the specific bug where:
-    1. First chunk has padding (mask=[F,F,T,T])
-    2. Second chunk has no mask (None)
-    3. The padding from first chunk should still be respected in attention
-    """
-    torch.manual_seed(42)
-    chunk_size = 4
-    B, H, Dh, Dv = 1, 2, 8, 8
-    max_cache_len = 8
-
-    attn = ChunkedSelfAttention(
-        num_heads=H,
-        head_dim=Dh,
-        value_head_dim=Dv,
-        chunk_size=chunk_size,
-        rope_base=10_000.0,
-        attention_dropout=0.0,
-    ).eval()
-
-    # First chunk: 4 tokens with first 2 padded
-    q1 = torch.randn(B, 4, H, Dh)
-    k1 = torch.randn(B, 4, H, Dh)
-    v1 = torch.randn(B, 4, H, Dv)
-    mask1 = torch.tensor([[False, False, True, True]])
-
-    out1, cache1, pos1 = attn(
-        q1,
-        k1,
-        v1,
-        start_index=0,
-        cache=None,
-        attn_mask=mask1,
-        training=False,
-        max_cache_len=max_cache_len,
-        return_cache=True,
-        return_position=True,
-    )
-
-    assert cache1.mask is not None
-    assert torch.equal(cache1.mask, mask1)
-
-    # Second chunk: 4 tokens with NO mask (all valid implied)
-    q2 = torch.randn(B, 4, H, Dh)
-    k2 = torch.randn(B, 4, H, Dh)
-    v2 = torch.randn(B, 4, H, Dv)
-    mask2 = None  # THE BUG: no current mask
-
-    out2, cache2, pos2 = attn(
-        q2,
-        k2,
-        v2,
-        start_index=pos1,
-        cache=cache1,
-        attn_mask=mask2,
-        training=False,
-        max_cache_len=max_cache_len,
-        return_cache=True,
-        return_position=True,
-    )
-
-    # Cache should have combined mask
-    assert cache2.mask is not None
-    assert cache2.length == 8  # 4 + 4
-
-    # Expected mask: [F,F,T,T,T,T,T,T] (original padding + all-valid new tokens)
-    expected_mask = torch.tensor([[False, False, True, True, True, True, True, True]])
-    assert torch.equal(cache2.mask, expected_mask), (
-        f"Expected mask {expected_mask.tolist()}, got {cache2.mask.tolist()}"
-    )
-
-
 @torch.no_grad()
 def test_per_batch_positions_variable_length() -> None:
     """Per-batch positions should produce correct RoPE and causal masks for variable-length batches.
@@ -2034,8 +1654,11 @@ def test_per_batch_positions_variable_length() -> None:
     # Positions should be a tensor of shape (B,)
     assert pos.shape == (B,), f"Expected pos shape (B,), got {pos.shape}"
 
-    # Both batches should have same total count (4 tokens processed)
-    assert (pos == chunk_size).all(), f"Expected all positions to be {chunk_size}, got {pos}"
+    # Counts should reflect valid tokens per batch
+    expected_pos = torch.tensor([2, 4], dtype=pos.dtype)
+    assert torch.equal(
+        pos, expected_pos
+    ), f"Expected positions {expected_pos.tolist()}, got {pos.tolist()}"
 
     # Cache should have mask reflecting padding
     assert cache.mask is not None
@@ -2069,10 +1692,10 @@ def test_per_batch_positions_variable_length() -> None:
     assert torch.isfinite(out2).all(), "Second chunk output should be finite"
 
     # Cache count should be updated
-    expected_count = chunk_size + 2  # 4 + 2 = 6
-    assert (cache2.count == expected_count).all(), (
-        f"Expected count {expected_count}, got {cache2.count}"
-    )
+    expected_count = torch.tensor([4, 6], dtype=cache2.count.dtype)
+    assert torch.equal(
+        cache2.count, expected_count
+    ), f"Expected count {expected_count.tolist()}, got {cache2.count.tolist()}"
 
 
 @torch.no_grad()

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -22,10 +22,10 @@ import torch
 
 from megalodon import MegalodonConfig, MegalodonForCausalLM, MegalodonModel
 from megalodon.modeling_megalodon import (
+    FFT_KERNEL_CHUNK,
     AttentionCache,
     ChunkedSelfAttention,
     ComplexEMA,
-    FFT_KERNEL_CHUNK,
     MegalodonAttention,
     RMSNorm,
     TimestepNorm,
@@ -994,7 +994,9 @@ def test_sliding_cache_multi_chunk_attention_window() -> None:
     assert cache2.length == max_cache_len
     pos2_int = int(pos2[0].item())
     assert int(cache2.count[0].item()) == pos1_int + chunk_size
-    assert int(cache2.start_index[0].item()) == int(cache2.count[0].item()) - cache2.length
+    assert (
+        int(cache2.start_index[0].item()) == int(cache2.count[0].item()) - cache2.length
+    )
     assert pos2_int == int(cache2.count[0].item())
 
     # Unbounded cache should retain the full history (2 * chunk_size).
@@ -1363,7 +1365,9 @@ def test_cema_mask_left_padding_matches_unbatched() -> None:
     x_left_padded = torch.zeros(1, D, L_total)
     x_left_padded[:, :, -L_valid:] = x_valid  # valid tokens at end
     mask_left = torch.zeros(1, L_total, dtype=torch.bool)
-    mask_left[:, -L_valid:] = True  # [False, False, False, False, True, True, True, True]
+    mask_left[:, -L_valid:] = (
+        True  # [False, False, False, False, True, True, True, True]
+    )
 
     y_left, h_left = cema(x_left_padded, compute_last_state=True, mask=mask_left)
 
@@ -1587,7 +1591,9 @@ def test_attention_cache_preserves_mask() -> None:
     # Continue generation with a new token
     next_token = torch.randint(0, cfg.vocab_size, (1, 1))
     next_mask = torch.ones(1, 1, dtype=torch.long)
-    out2 = model(next_token, attention_mask=next_mask, past_key_values=cache, use_cache=True)
+    out2 = model(
+        next_token, attention_mask=next_mask, past_key_values=cache, use_cache=True
+    )
 
     # Verify updated cache mask includes the new valid token
     updated_cache = out2.past_key_values[0]
@@ -1649,16 +1655,18 @@ def test_per_batch_positions_variable_length() -> None:
     assert torch.isfinite(out_masked).all(), "Output should be finite"
 
     # Cache count should be a tensor of shape (B,)
-    assert cache.count.shape == (B,), f"Expected count shape (B,), got {cache.count.shape}"
+    assert cache.count.shape == (B,), (
+        f"Expected count shape (B,), got {cache.count.shape}"
+    )
 
     # Positions should be a tensor of shape (B,)
     assert pos.shape == (B,), f"Expected pos shape (B,), got {pos.shape}"
 
     # Counts should reflect valid tokens per batch
     expected_pos = torch.tensor([2, 4], dtype=pos.dtype)
-    assert torch.equal(
-        pos, expected_pos
-    ), f"Expected positions {expected_pos.tolist()}, got {pos.tolist()}"
+    assert torch.equal(pos, expected_pos), (
+        f"Expected positions {expected_pos.tolist()}, got {pos.tolist()}"
+    )
 
     # Cache should have mask reflecting padding
     assert cache.mask is not None
@@ -1693,9 +1701,9 @@ def test_per_batch_positions_variable_length() -> None:
 
     # Cache count should be updated
     expected_count = torch.tensor([4, 6], dtype=cache2.count.dtype)
-    assert torch.equal(
-        cache2.count, expected_count
-    ), f"Expected count {expected_count.tolist()}, got {cache2.count.tolist()}"
+    assert torch.equal(cache2.count, expected_count), (
+        f"Expected count {expected_count.tolist()}, got {cache2.count.tolist()}"
+    )
 
 
 @torch.no_grad()

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -550,7 +550,7 @@ def test_sdpa_with_prefix_and_padding_matches_reference() -> None:
     v = torch.randn(B, chunk_size, num_heads, value_head_dim)
     cache_k = torch.randn(B, prefix_len, num_heads, head_dim)
     cache_v = torch.randn(B, prefix_len, num_heads, value_head_dim)
-    cache = AttentionCache(cache_k, cache_v, prefix_len)
+    cache = AttentionCache(cache_k, cache_v, torch.tensor([prefix_len]))
     attn_mask = torch.tensor([[1, 0, 1, 1]], dtype=torch.long)
 
     out_sdpa, _ = attn(
@@ -939,12 +939,12 @@ def test_attention_cache_truncation_keeps_causality() -> None:
     B = 1
     k_past = torch.randn(B, past_len, H, Dh)
     v_past = torch.randn(B, past_len, H, Dv)
-    cache_full = AttentionCache(k_past, v_past, past_len)
+    cache_full = AttentionCache(k_past, v_past, torch.tensor([past_len]))
 
     q_new = torch.randn(B, new_len, H, Dh)
     k_new = torch.randn(B, new_len, H, Dh)
     v_new = torch.randn(B, new_len, H, Dv)
-    pos_in_chunk = cache_full.count % chunk_size
+    pos_in_chunk = int(cache_full.count[0].item()) % chunk_size
     effective_limit = min(max_cache_len, pos_in_chunk) if pos_in_chunk > 0 else 0
 
     # Path A: provide full cache, let attention clamp internally.
@@ -974,7 +974,7 @@ def test_attention_cache_truncation_keeps_causality() -> None:
         q_new,
         k_new,
         v_new,
-        start_index=cache_full.count,
+        start_index=int(cache_full.count[0].item()),
         cache=cache_manual,
         attn_mask=None,
         training=False,
@@ -1025,9 +1025,10 @@ def test_sliding_cache_multi_chunk_attention_window() -> None:
     assert (
         cache1 is not None
         and cache1.length == chunk_size
-        and cache1.count == chunk_size
+        and int(cache1.count[0].item()) == chunk_size
     )
-    assert pos1 == chunk_size
+    pos1_int = int(pos1[0].item())
+    assert pos1_int == chunk_size
 
     q2 = torch.randn(B, chunk_size, H, Dh)
     k2 = torch.randn(B, chunk_size, H, Dh)
@@ -1037,7 +1038,7 @@ def test_sliding_cache_multi_chunk_attention_window() -> None:
         q2,
         k2,
         v2,
-        start_index=pos1,
+        start_index=pos1_int,
         cache=cache1,
         attn_mask=mask,
         training=False,
@@ -1049,16 +1050,17 @@ def test_sliding_cache_multi_chunk_attention_window() -> None:
     assert out2.shape == (B, chunk_size, H * Dv)
     assert cache2 is not None
     assert cache2.length == max_cache_len
-    assert cache2.count == pos1 + chunk_size
-    assert cache2.start_index == cache2.count - cache2.length
-    assert pos2 == cache2.count
+    pos2_int = int(pos2[0].item())
+    assert int(cache2.count[0].item()) == pos1_int + chunk_size
+    assert int(cache2.start_index[0].item()) == int(cache2.count[0].item()) - cache2.length
+    assert pos2_int == int(cache2.count[0].item())
 
     # Unbounded cache should retain the full history (2 * chunk_size).
     out_u, cache_u, pos_u = attn(
         q2,
         k2,
         v2,
-        start_index=pos1,
+        start_index=pos1_int,
         cache=cache1,
         attn_mask=mask,
         training=False,
@@ -1068,21 +1070,21 @@ def test_sliding_cache_multi_chunk_attention_window() -> None:
         return_position=True,
     )
     assert cache_u is not None and cache_u.length == chunk_size * 2
-    assert pos_u == cache_u.count
+    assert int(pos_u[0].item()) == int(cache_u.count[0].item())
     assert torch.isfinite(out_u).all()
 
     # Manual reference with sliding window (keep last max_cache_len keys)
     q1_rot, k1_rot = attn.rope(q1, k1, start_index=0)
-    q2_rot, k2_rot = attn.rope(q2, k2, start_index=pos1)
+    q2_rot, k2_rot = attn.rope(q2, k2, start_index=pos1_int)
     k_all = torch.cat([k1_rot, k2_rot], dim=1)
     v_all = torch.cat([v1, v2], dim=1)
     k_keep = k_all[:, -max_cache_len:]
     v_keep = v_all[:, -max_cache_len:]
 
     key_positions = torch.arange(
-        pos1 + chunk_size - max_cache_len, pos1 + chunk_size, device=q1.device
+        pos1_int + chunk_size - max_cache_len, pos1_int + chunk_size, device=q1.device
     )
-    query_positions = torch.arange(pos1, pos1 + chunk_size, device=q1.device)
+    query_positions = torch.arange(pos1_int, pos1_int + chunk_size, device=q1.device)
     causal = key_positions.view(1, 1, 1, max_cache_len) <= query_positions.view(
         1, 1, chunk_size, 1
     )
@@ -1683,7 +1685,7 @@ def test_mask_trim_direction_matches_kv() -> None:
     cache_k = torch.randn(B, 6, H, Dh)
     cache_v = torch.randn(B, 6, H, Dv)
     cache_mask = torch.tensor([[False, False, True, True, True, True]])
-    cache = AttentionCache(k=cache_k, v=cache_v, count=6, mask=cache_mask)
+    cache = AttentionCache(k=cache_k, v=cache_v, count=torch.tensor([6]), mask=cache_mask)
 
     # Add 2 new tokens with all-valid mask
     q = torch.randn(B, 2, H, Dh)
@@ -1838,7 +1840,9 @@ def test_attend_mask_combinations(
             cache_mask = torch.tensor([[False, False, True, True]])
         else:
             cache_mask = None
-        cache = AttentionCache(k=cache_k, v=cache_v, count=cache_len, mask=cache_mask)
+        cache = AttentionCache(
+            k=cache_k, v=cache_v, count=torch.tensor([cache_len]), mask=cache_mask
+        )
         start_index = cache_len
     else:
         cache = None
@@ -1968,4 +1972,99 @@ def test_cache_mask_continuity_without_current_mask() -> None:
     expected_mask = torch.tensor([[False, False, True, True, True, True, True, True]])
     assert torch.equal(cache2.mask, expected_mask), (
         f"Expected mask {expected_mask.tolist()}, got {cache2.mask.tolist()}"
+    )
+
+
+@torch.no_grad()
+def test_per_batch_positions_variable_length() -> None:
+    """Per-batch positions should produce correct RoPE and causal masks for variable-length batches.
+
+    This tests the per-batch position tracking where:
+    1. Batch 0 has padding (positions 2,3,4,5 due to left-padding)
+    2. Batch 1 has no padding (positions 0,1,2,3)
+    3. Both batches get correct RoPE and causal masks for their actual positions
+    """
+    torch.manual_seed(42)
+    chunk_size = 4
+    B, H, Dh, Dv = 2, 2, 8, 8
+    max_cache_len = 8
+
+    attn = ChunkedSelfAttention(
+        num_heads=H,
+        head_dim=Dh,
+        value_head_dim=Dv,
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    ).eval()
+
+    # Create inputs for 2 batches with same content for comparison
+    q = torch.randn(B, chunk_size, H, Dh)
+    k = torch.randn(B, chunk_size, H, Dh)
+    v = torch.randn(B, chunk_size, H, Dv)
+
+    # Batch 0 has 2 padding tokens, batch 1 has no padding
+    mask = torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]], dtype=torch.long)
+
+    # Run with mask
+    out_masked, cache, pos = attn(
+        q,
+        k,
+        v,
+        start_index=0,
+        cache=None,
+        attn_mask=mask,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    # Outputs should be finite
+    assert torch.isfinite(out_masked).all(), "Output should be finite"
+
+    # Cache count should be a tensor of shape (B,)
+    assert cache.count.shape == (B,), f"Expected count shape (B,), got {cache.count.shape}"
+
+    # Positions should be a tensor of shape (B,)
+    assert pos.shape == (B,), f"Expected pos shape (B,), got {pos.shape}"
+
+    # Both batches should have same total count (4 tokens processed)
+    assert (pos == chunk_size).all(), f"Expected all positions to be {chunk_size}, got {pos}"
+
+    # Cache should have mask reflecting padding
+    assert cache.mask is not None
+    expected_mask = torch.tensor([[False, False, True, True], [True, True, True, True]])
+    assert torch.equal(cache.mask, expected_mask), (
+        f"Expected mask {expected_mask.tolist()}, got {cache.mask.tolist()}"
+    )
+
+    # Run second chunk using position_ids to specify different starting positions
+    q2 = torch.randn(B, 2, H, Dh)
+    k2 = torch.randn(B, 2, H, Dh)
+    v2 = torch.randn(B, 2, H, Dv)
+
+    # Batch 0 starts at position 4, batch 1 at position 4
+    # (In a real scenario with different lengths, these would differ)
+
+    out2, cache2, pos2 = attn(
+        q2,
+        k2,
+        v2,
+        start_index=chunk_size,  # Default when no cache
+        cache=cache,
+        attn_mask=None,  # All valid
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    # Outputs should be finite
+    assert torch.isfinite(out2).all(), "Second chunk output should be finite"
+
+    # Cache count should be updated
+    expected_count = chunk_size + 2  # 4 + 2 = 6
+    assert (cache2.count == expected_count).all(), (
+        f"Expected count {expected_count}, got {cache2.count}"
     )

--- a/tests/test_megalodon_smoke.py
+++ b/tests/test_megalodon_smoke.py
@@ -1791,3 +1791,181 @@ def test_rejects_max_cache_len_below_chunk_size() -> None:
         return_position=True,
     )
     assert out2.shape == (B, 10, H * Dv)
+
+
+@pytest.mark.parametrize(
+    "cache_present,cache_has_mask,current_has_mask",
+    [
+        (False, False, False),  # No cache, no mask
+        (False, False, True),  # No cache, with current mask
+        (True, False, False),  # Cache without mask, no current mask
+        (True, False, True),  # Cache without mask, with current mask
+        (True, True, False),  # Cache WITH mask, NO current mask (THE BUG)
+        (True, True, True),  # Cache with mask, with current mask
+    ],
+)
+@torch.no_grad()
+def test_attend_mask_combinations(
+    cache_present: bool, cache_has_mask: bool, current_has_mask: bool
+) -> None:
+    """Test all combinations of cache/mask presence in attend_single_chunk.
+
+    This is a regression test for the bug where cache.mask was ignored when
+    mask_blk (current mask) was None. The fix ensures prefix mask is always
+    applied when cache.mask exists.
+    """
+    torch.manual_seed(42)
+    chunk_size = 4
+    B, H, Dh, Dv = 1, 2, 8, 8
+    max_cache_len = 8
+
+    attn = ChunkedSelfAttention(
+        num_heads=H,
+        head_dim=Dh,
+        value_head_dim=Dv,
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    ).eval()
+
+    # Build cache if needed
+    if cache_present:
+        cache_len = 4
+        cache_k = torch.randn(B, cache_len, H, Dh)
+        cache_v = torch.randn(B, cache_len, H, Dv)
+        if cache_has_mask:
+            # First 2 positions are padding
+            cache_mask = torch.tensor([[False, False, True, True]])
+        else:
+            cache_mask = None
+        cache = AttentionCache(k=cache_k, v=cache_v, count=cache_len, mask=cache_mask)
+        start_index = cache_len
+    else:
+        cache = None
+        start_index = 0
+
+    # Build current input
+    q = torch.randn(B, 2, H, Dh)
+    k = torch.randn(B, 2, H, Dh)
+    v = torch.randn(B, 2, H, Dv)
+
+    if current_has_mask:
+        current_mask = torch.ones(B, 2, dtype=torch.bool)
+    else:
+        current_mask = None
+
+    # Run attention
+    out, new_cache, new_pos = attn(
+        q,
+        k,
+        v,
+        start_index=start_index,
+        cache=cache,
+        attn_mask=current_mask,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    # Basic shape checks
+    assert out.shape == (B, 2, H * Dv)
+    assert new_cache is not None
+
+    # Verify mask consistency
+    if cache_has_mask or current_has_mask:
+        # When any mask is present, output cache must have mask
+        assert new_cache.mask is not None, (
+            f"Cache mask should be present when cache_has_mask={cache_has_mask} "
+            f"or current_has_mask={current_has_mask}"
+        )
+        # Mask length must match K/V length
+        assert new_cache.mask.shape[1] == new_cache.length, (
+            f"Mask length {new_cache.mask.shape[1]} != cache length {new_cache.length}"
+        )
+
+    # Special check for THE BUG case: cache.mask present, current mask None
+    if cache_has_mask and not current_has_mask:
+        # The new cache should still have mask reflecting the padding
+        assert new_cache.mask is not None
+        # The mask should include all-ones for the new tokens
+        # After concat: [F,F,T,T] + [T,T] = [F,F,T,T,T,T] (if no trimming)
+        # The rightmost positions (new tokens) should be True
+        assert new_cache.mask[0, -2:].all(), (
+            f"New tokens should be valid (True), got {new_cache.mask[0, -2:].tolist()}"
+        )
+
+
+@torch.no_grad()
+def test_cache_mask_continuity_without_current_mask() -> None:
+    """Regression test: cache.mask must be respected even when current mask is None.
+
+    This tests the specific bug where:
+    1. First chunk has padding (mask=[F,F,T,T])
+    2. Second chunk has no mask (None)
+    3. The padding from first chunk should still be respected in attention
+    """
+    torch.manual_seed(42)
+    chunk_size = 4
+    B, H, Dh, Dv = 1, 2, 8, 8
+    max_cache_len = 8
+
+    attn = ChunkedSelfAttention(
+        num_heads=H,
+        head_dim=Dh,
+        value_head_dim=Dv,
+        chunk_size=chunk_size,
+        rope_base=10_000.0,
+        attention_dropout=0.0,
+    ).eval()
+
+    # First chunk: 4 tokens with first 2 padded
+    q1 = torch.randn(B, 4, H, Dh)
+    k1 = torch.randn(B, 4, H, Dh)
+    v1 = torch.randn(B, 4, H, Dv)
+    mask1 = torch.tensor([[False, False, True, True]])
+
+    out1, cache1, pos1 = attn(
+        q1,
+        k1,
+        v1,
+        start_index=0,
+        cache=None,
+        attn_mask=mask1,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    assert cache1.mask is not None
+    assert torch.equal(cache1.mask, mask1)
+
+    # Second chunk: 4 tokens with NO mask (all valid implied)
+    q2 = torch.randn(B, 4, H, Dh)
+    k2 = torch.randn(B, 4, H, Dh)
+    v2 = torch.randn(B, 4, H, Dv)
+    mask2 = None  # THE BUG: no current mask
+
+    out2, cache2, pos2 = attn(
+        q2,
+        k2,
+        v2,
+        start_index=pos1,
+        cache=cache1,
+        attn_mask=mask2,
+        training=False,
+        max_cache_len=max_cache_len,
+        return_cache=True,
+        return_position=True,
+    )
+
+    # Cache should have combined mask
+    assert cache2.mask is not None
+    assert cache2.length == 8  # 4 + 4
+
+    # Expected mask: [F,F,T,T,T,T,T,T] (original padding + all-valid new tokens)
+    expected_mask = torch.tensor([[False, False, True, True, True, True, True, True]])
+    assert torch.equal(cache2.mask, expected_mask), (
+        f"Expected mask {expected_mask.tolist()}, got {cache2.mask.tolist()}"
+    )

--- a/tests/test_megalodon_training.py
+++ b/tests/test_megalodon_training.py
@@ -258,12 +258,13 @@ def test_custom_ignore_index() -> None:
 
     with torch.no_grad():
         # Default ignore_index=-100: token 0 contributes to loss normally
-        out_default = model(
-            input_ids=inputs, labels=labels_custom, return_dict=True
-        )
+        out_default = model(input_ids=inputs, labels=labels_custom, return_dict=True)
         # Custom ignore_index=0: token 0 positions are excluded from loss
         out_custom = model(
-            input_ids=inputs, labels=labels_custom, ignore_index=custom_ignore, return_dict=True
+            input_ids=inputs,
+            labels=labels_custom,
+            ignore_index=custom_ignore,
+            return_dict=True,
         )
 
     # Both should be finite


### PR DESCRIPTION
When porting this to jax for faster CEMA, I found a bug in the implementation: MegalodonAttention passed attn_mask to TimestepNorm and attention but not to CEMA.

Since TimestepNorm normalizes padding tokens (zeros) to non-zero values, CEMA would incorporate these fake values into its recurrence, breaking the invariant that batched (padded) processing should yield the same cache as unbatched.

Fixes:

- CEMA now receives the attention mask, preventing padding tokens from contaminating the EMA hidden state
- h_last is extracted at the last valid position per batch item, ensuring cached state matchesunbatched processing

Things changed:

- ComplexEMA.forward: Add mask parameter; zero masked positions before recurrence; track last_valid_idx for correct h_last extraction
- MegalodonAttention.forward: Pass attn_mask to self.cema()
- 4 regression tests added
